### PR TITLE
[Governance] show home page when loading proposals table

### DIFF
--- a/src/pages/LandingPage/Index.tsx
+++ b/src/pages/LandingPage/Index.tsx
@@ -14,13 +14,6 @@ export default function LandingPage() {
     ProposalsTableRef.current?.scrollIntoView({behavior: "smooth"});
   };
 
-  if (!proposalTableData) {
-    // TODO: handle errors
-    return <>No Data</>;
-  }
-
-  const {nextProposalId} = proposalTableData;
-
   return (
     <Grid item xs={12}>
       <Header />
@@ -28,10 +21,12 @@ export default function LandingPage() {
       <Hidden smDown>
         <Instructions onVoteProposalButtonClick={scrollTableIntoView} />
       </Hidden>
-      <ProposalsTable
-        nextProposalId={nextProposalId}
-        ProposalsTableRef={ProposalsTableRef}
-      />
+      {proposalTableData && (
+        <ProposalsTable
+          nextProposalId={proposalTableData.nextProposalId}
+          ProposalsTableRef={ProposalsTableRef}
+        />
+      )}
     </Grid>
   );
 }


### PR DESCRIPTION
It takes time for the proposals table data to load. While loading the data, we should show other parts of the home page.

<img width="1819" alt="Screen Shot 2022-09-22 at 4 50 51 PM" src="https://user-images.githubusercontent.com/109111707/191870512-d45e94bb-4347-468c-8b8f-8132992b9711.png">
