### PR TITLE
Nav bar and headers experience

### DIFF
--- a/src/GovernanceRoutes.tsx
+++ b/src/GovernanceRoutes.tsx
@@ -5,8 +5,9 @@ import NotFoundPage from "./pages/NotFoundPage";
 import Layout from "./pages/layout";
 import {ProposalPage} from "./pages/Proposal/Index";
 import {CreateProposalPage} from "./pages/CreateProposal/Index";
-import {Staking} from "./pages/Stake/Index";
 import Voting from "./pages/Voting";
+import StakingPage from "./pages/Stake/Index";
+import ProposalsPage from "./pages/Proposals/Index";
 
 export default function GovernanceRoutes() {
   return (
@@ -16,7 +17,8 @@ export default function GovernanceRoutes() {
         <Route path="/proposal/:id" element={<ProposalPage />} />
         <Route path="/proposal/:id/vote" element={<Voting />} />
         <Route path="/proposal/create" element={<CreateProposalPage />} />
-        <Route path="/staking" element={<Staking />} />
+        <Route path="/proposals" element={<ProposalsPage />} />
+        <Route path="/staking" element={<StakingPage />} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </Layout>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -24,3 +24,27 @@ export default function Header() {
     </>
   );
 }
+
+type IndividualPageHeaderProps = {
+  title: string;
+};
+
+export function IndividualPageHeader({title}: IndividualPageHeaderProps) {
+  return (
+    <>
+      <Grid container alignItems="center">
+        <Grid item xs={12} sm={6}>
+          <Typography variant="h3" component="h3">
+            {title}
+          </Typography>
+        </Grid>
+        <Hidden smDown>
+          <Grid item xs={12} sm={6} textAlign={{sm: "right"}}>
+            <WalletButton />
+          </Grid>
+        </Hidden>
+      </Grid>
+      <DividerHero />
+    </>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,7 +4,7 @@ import DividerHero from "./DividerHero";
 import HeadingSub from "./HeadingSub";
 import {WalletButton} from "./WalletButton";
 
-export default function Header() {
+export function HomePageHeader() {
   return (
     <>
       <Grid container alignItems="center">

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -16,6 +16,18 @@ export default function Nav() {
       <Button
         variant="nav"
         component={NavLink}
+        to="/proposals"
+        title="Proposals"
+        sx={{
+          color: "inherit",
+          fontSize: {sm: ".875rem", md: "1rem"},
+        }}
+      >
+        Proposals
+      </Button>
+      <Button
+        variant="nav"
+        component={NavLink}
         to="/staking"
         title="Staking"
         sx={{

--- a/src/pages/LandingPage/Index.tsx
+++ b/src/pages/LandingPage/Index.tsx
@@ -1,6 +1,6 @@
 import React, {useRef} from "react";
 import {Grid, Hidden} from "@mui/material";
-import Header from "../../components/Header";
+import {HomePageHeader} from "../../components/Header";
 import {Header as ProposalsHeader} from "./Header";
 import {ProposalsTable} from "./Table";
 import {Instructions} from "./Instructions";
@@ -16,7 +16,7 @@ export default function LandingPage() {
 
   return (
     <Grid item xs={12}>
-      <Header />
+      <HomePageHeader />
       <ProposalsHeader onVoteProposalButtonClick={scrollTableIntoView} />
       <Hidden smDown>
         <Instructions onVoteProposalButtonClick={scrollTableIntoView} />

--- a/src/pages/LandingPage/Table.tsx
+++ b/src/pages/LandingPage/Table.tsx
@@ -189,7 +189,8 @@ type ProposalsTableProps = {
   proposals?: Proposal[];
   columns?: ProposalColumn[];
   nextProposalId: string;
-  ProposalsTableRef: React.MutableRefObject<HTMLDivElement | null>;
+  ProposalsTableRef?: React.MutableRefObject<HTMLDivElement | null>;
+  hideTitle?: boolean;
 };
 
 // TODO: generalize Table component for transactions and proposals
@@ -197,6 +198,7 @@ export function ProposalsTable({
   nextProposalId,
   columns = DEFAULT_COLUMNS,
   ProposalsTableRef,
+  hideTitle,
 }: ProposalsTableProps) {
   const proposalRows = [];
   // we need to iterate from (0...nextProposalId)
@@ -228,7 +230,7 @@ export function ProposalsTable({
   return (
     <Grid ref={ProposalsTableRef}>
       <Stack spacing={1}>
-        <Title>Proposals</Title>
+        {hideTitle !== true && <Title>Proposals</Title>}
         <Box sx={{width: "auto", overflowX: "auto"}}>{tableComponent}</Box>
       </Stack>
     </Grid>

--- a/src/pages/Proposal/Index.tsx
+++ b/src/pages/Proposal/Index.tsx
@@ -6,7 +6,7 @@ import {ProposalContent} from "./Content";
 import {useParams} from "react-router-dom";
 import {useGetProposal} from "../../api/hooks/useGetProposal";
 import {EmptyProposal} from "./EmptyProposal";
-import Header from "../../components/Header";
+import {IndividualPageHeader} from "../../components/Header";
 import GoBack from "../../components/GoBack";
 
 export type ProposalPageURLParams = {
@@ -24,7 +24,7 @@ export const ProposalPage = () => {
 
   return (
     <Grid container>
-      <Header />
+      <IndividualPageHeader title="Proposal" />
       <GoBack to={"/"} />
       <Grid item md={12} xs={12} sx={{mb: 6}}>
         <ProposalHeader proposal={proposal} />

--- a/src/pages/Proposals/Index.tsx
+++ b/src/pages/Proposals/Index.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import {useGetProposalsTableData} from "../../api/hooks/useGetProposalsTableData";
+import {ProposalsTable} from "../LandingPage/Table";
+import {IndividualPageHeader} from "../../components/Header";
+
+export default function ProposalsPage() {
+  const proposalTableData = useGetProposalsTableData();
+
+  return (
+    <>
+      <IndividualPageHeader title="Proposals" />
+      {proposalTableData && (
+        <ProposalsTable
+          nextProposalId={proposalTableData.nextProposalId}
+          hideTitle
+        />
+      )}
+    </>
+  );
+}

--- a/src/pages/Stake/Index.tsx
+++ b/src/pages/Stake/Index.tsx
@@ -1,15 +1,15 @@
 import React from "react";
 
 import {useWalletContext} from "../../context/wallet/context";
-import Header from "../../components/Header";
 import {CreateOrEdit} from "./components/CreateOrEdit";
+import {IndividualPageHeader} from "../../components/Header";
 
-export function Staking() {
+export default function StakingPage() {
   const {isConnected, accountAddress} = useWalletContext();
 
   return (
     <>
-      <Header />
+      <IndividualPageHeader title="Staking" />
       <CreateOrEdit
         isWalletConnected={isConnected}
         accountAddress={accountAddress}

--- a/src/pages/Voting/index.tsx
+++ b/src/pages/Voting/index.tsx
@@ -3,7 +3,7 @@ import React, {useState} from "react";
 import {useParams} from "react-router-dom";
 import {useGetProposal} from "../../api/hooks/useGetProposal";
 import GoBack from "../../components/GoBack";
-import Header from "../../components/Header";
+import {IndividualPageHeader} from "../../components/Header";
 import {EmptyProposal} from "../Proposal/EmptyProposal";
 import {ProposalHeader} from "../Proposal/Header";
 import {AddressToVoteMap} from "../Types";
@@ -26,7 +26,7 @@ export default function Voting() {
 
   return (
     <Grid container>
-      <Header />
+      <IndividualPageHeader title="Vote" />
       <GoBack to={"/"} />
       <Grid item xs={12}>
         <ProposalHeader proposal={proposal} />


### PR DESCRIPTION
To address Raj's feedback https://aptos-org.slack.com/archives/C03RGDZ658X/p1665172529662249, this PR made a few changes to the nav bar and headers. 

### Home page (no change)
<img width="1703" alt="Screen Shot 2022-10-07 at 4 18 32 PM" src="https://user-images.githubusercontent.com/109111707/194674760-70e86425-6cd8-4f8e-9506-e7ae9d51ce15.png">


### Proposals page
<img width="1706" alt="Screen Shot 2022-10-07 at 4 18 42 PM" src="https://user-images.githubusercontent.com/109111707/194674742-6ff63807-9bb3-4333-b687-990759c4df27.png">

### Staking page
<img width="1705" alt="Screen Shot 2022-10-07 at 4 18 53 PM" src="https://user-images.githubusercontent.com/109111707/194674774-c7fc80e1-ed73-4f30-9570-82a21694f1a1.png">

### Individual proposal page
<img width="1705" alt="Screen Shot 2022-10-07 at 4 19 09 PM" src="https://user-images.githubusercontent.com/109111707/194674803-5c0a6839-e64b-4462-a990-b4fbb5895214.png">

