### PR TITLE
Fetch stake pool addresses by connected wallet account

### DIFF
--- a/src/api/hooks/useGraphqlClient.tsx
+++ b/src/api/hooks/useGraphqlClient.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import {
+  ApolloClient,
+  InMemoryCache,
+  ApolloProvider,
+  HttpLink,
+  NormalizedCacheObject,
+} from "@apollo/client";
+import {useEffect, useState} from "react";
+
+import {useGlobalState} from "../../context/globalState";
+import {NetworkName} from "../../constants";
+
+function getGraphqlURI(networkName: NetworkName): string | undefined {
+  switch (networkName) {
+    case "mainnet":
+      return process.env.REACT_APP_INDEXER_GRAPHQL_MAINNET;
+    case "testnet":
+      return process.env.REACT_APP_INDEXER_GRAPHQL_TESTNET;
+    case "Devnet":
+      return process.env.REACT_APP_INDEXER_GRAPHQL_DEVNET;
+    case "local":
+      return undefined;
+    default:
+      return undefined;
+  }
+}
+
+function getGraphqlClient(
+  networkName: NetworkName,
+): ApolloClient<NormalizedCacheObject> {
+  return new ApolloClient({
+    link: new HttpLink({
+      uri: getGraphqlURI(networkName),
+    }),
+    cache: new InMemoryCache(),
+  });
+}
+
+export function useGetGraphqlClient() {
+  const [state, _] = useGlobalState();
+  const [graphqlClient, setGraphqlClient] = useState<
+    ApolloClient<NormalizedCacheObject>
+  >(getGraphqlClient(state.network_name));
+
+  useEffect(() => {
+    setGraphqlClient(getGraphqlClient(state.network_name));
+  }, [state.network_name]);
+
+  return graphqlClient;
+}
+
+type GraphqlClientProviderProps = {
+  children: React.ReactNode;
+};
+
+export function GraphqlClientProvider({children}: GraphqlClientProviderProps) {
+  const graphqlClient = useGetGraphqlClient();
+
+  return <ApolloProvider client={graphqlClient}>{children}</ApolloProvider>;
+}

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -8,7 +8,7 @@ export const networks = {
   mainnet: "https://fullnode.mainnet.aptoslabs.com/",
   testnet: "https://testnet.aptoslabs.com",
   Devnet: devnetUrl,
-  local: "http://127.0.0.1:61014/v1",
+  local: "http://localhost:8080",
 };
 
 export type NetworkName = keyof typeof networks;

--- a/src/pages/Voting/components/AddressesList.tsx
+++ b/src/pages/Voting/components/AddressesList.tsx
@@ -1,11 +1,15 @@
-import {Chip, Divider, Grid, Stack} from "@mui/material";
-import {useState} from "react";
+import {Box, Chip, Divider, Grid, Stack, Typography} from "@mui/material";
+import {useEffect, useState} from "react";
+import {gql, useQuery as useGraphqlQuery} from "@apollo/client";
+
+import {useGlobalState} from "../../../context/globalState";
+import {useWalletContext} from "../../../context/wallet/context";
 import VoteButtons from "../../Proposal/card/VoteButtons";
 import {AddressToVoteMap, Proposal} from "../../Types";
 import {isVotingClosed} from "../../utils";
+import hasAddressVoted from "../api/hasAddressVoted";
 
 type AddressesListProps = {
-  addressVoteMap: AddressToVoteMap[] | undefined;
   proposal: Proposal;
 };
 
@@ -60,16 +64,116 @@ function AddressVotingState({
   );
 }
 
-export default function AddressesList({
-  addressVoteMap,
-  proposal,
-}: AddressesListProps) {
+const STAKE_POOL_ADDRESS_BY_VOTER_QUERY = gql`
+  query current_staking_pool_voter($voter_address: String) {
+    current_staking_pool_voter(where: {voter_address: {_eq: $voter_address}}) {
+      staking_pool_address
+    }
+  }
+`;
+
+type CurrentStakingPoolVoter = {
+  current_staking_pool_voter: [
+    {
+      __typename: string;
+      staking_pool_address: string;
+    },
+  ];
+};
+
+export default function AddressesList({proposal}: AddressesListProps) {
+  const {accountAddress} = useWalletContext();
+  const [state, _] = useGlobalState();
+  const [mapLoading, setMapLoading] = useState<boolean>(false);
+  const [addressVoteMap, setAddressVoteMap] = useState<AddressToVoteMap[]>();
+
+  const {loading, error, data} = useGraphqlQuery(
+    STAKE_POOL_ADDRESS_BY_VOTER_QUERY,
+    {
+      variables: {
+        voter_address:
+          "0x8ac6fe79b3656feda6485fcf872e00033dd35cd9d8e10b485e3dee34949b2f47",
+      },
+    },
+  );
+
+  const fetchHasAccountVoted = async (
+    poolAddress: string,
+  ): Promise<AddressToVoteMap> => {
+    const result = await hasAddressVoted(
+      poolAddress,
+      proposal.proposal_id,
+      state,
+    );
+    const addressToVotemap = {
+      poolAddress,
+      voted: result,
+    };
+    return addressToVotemap;
+  };
+
+  const fetchAccounts = async (
+    poolAddresses: CurrentStakingPoolVoter,
+  ): Promise<void> => {
+    const map = poolAddresses.current_staking_pool_voter.map(
+      async (poolAddress) => {
+        const result = await fetchHasAccountVoted(
+          poolAddress.staking_pool_address,
+        );
+        return result;
+      },
+    );
+
+    const addressesVotesMap = await Promise.all(map);
+    setMapLoading(false);
+    setAddressVoteMap(addressesVotesMap);
+  };
+
+  useEffect(() => {
+    if (data !== undefined) {
+      setMapLoading(true);
+      fetchAccounts(data);
+    }
+  }, [data]);
+
+  if (loading || mapLoading) {
+    return (
+      <Stack sx={{width: "100%"}} mt={4}>
+        <Typography variant="h4" mb={4}>
+          Loading
+        </Typography>
+      </Stack>
+    );
+  }
+
+  if (error) {
+    return (
+      <Stack sx={{width: "100%"}} mt={4}>
+        <Typography variant="h4" mb={4}>
+          {error.message}
+        </Typography>
+      </Stack>
+    );
+  }
+
+  if (data.current_staking_pool_voter.length === 0) {
+    return (
+      <Stack sx={{width: "100%"}} mt={4}>
+        <Typography variant="h4" mb={4}>
+          You don't have a voting power for any staking pool address
+        </Typography>
+      </Stack>
+    );
+  }
+
   return (
-    <>
+    <Stack sx={{width: "100%"}} mt={4}>
+      <Typography variant="h4" mb={4}>
+        Stake Pool Addresses
+      </Typography>
       {addressVoteMap?.map((account, index) => {
         return (
-          <Stack sx={{width: "100%"}}>
-            <Divider sx={{mb: "2rem"}} variant="dotted" />
+          <Stack key={account.poolAddress}>
             <AddressVotingState
               account={account}
               index={index}
@@ -78,6 +182,6 @@ export default function AddressesList({
           </Stack>
         );
       })}
-    </>
+    </Stack>
   );
 }

--- a/src/pages/Voting/components/AddressesList.tsx
+++ b/src/pages/Voting/components/AddressesList.tsx
@@ -94,8 +94,7 @@ export default function AddressesList({
     STAKE_POOL_ADDRESS_BY_VOTER_QUERY,
     {
       variables: {
-        voter_address:
-          "0x8ac6fe79b3656feda6485fcf872e00033dd35cd9d8e10b485e3dee34949b2f47",
+        voter_address: accountAddress,
       },
     },
   );

--- a/src/pages/Voting/components/AddressesList.tsx
+++ b/src/pages/Voting/components/AddressesList.tsx
@@ -1,16 +1,17 @@
-import {Box, Chip, Divider, Grid, Stack, Typography} from "@mui/material";
+import {Chip, Grid, Stack, Typography} from "@mui/material";
 import {useEffect, useState} from "react";
 import {gql, useQuery as useGraphqlQuery} from "@apollo/client";
 
 import {useGlobalState} from "../../../context/globalState";
-import {useWalletContext} from "../../../context/wallet/context";
 import VoteButtons from "../../Proposal/card/VoteButtons";
 import {AddressToVoteMap, Proposal} from "../../Types";
 import {isVotingClosed} from "../../utils";
 import hasAddressVoted from "../api/hasAddressVoted";
+import {MaybeHexString} from "aptos";
 
 type AddressesListProps = {
   proposal: Proposal;
+  accountAddress: MaybeHexString | null;
 };
 
 type AddressVotingStateProps = {
@@ -81,8 +82,10 @@ type CurrentStakingPoolVoter = {
   ];
 };
 
-export default function AddressesList({proposal}: AddressesListProps) {
-  const {accountAddress} = useWalletContext();
+export default function AddressesList({
+  proposal,
+  accountAddress,
+}: AddressesListProps) {
   const [state, _] = useGlobalState();
   const [mapLoading, setMapLoading] = useState<boolean>(false);
   const [addressVoteMap, setAddressVoteMap] = useState<AddressToVoteMap[]>();
@@ -134,7 +137,7 @@ export default function AddressesList({proposal}: AddressesListProps) {
       setMapLoading(true);
       fetchAccounts(data);
     }
-  }, [data]);
+  }, [data, accountAddress]);
 
   if (loading || mapLoading) {
     return (
@@ -160,7 +163,8 @@ export default function AddressesList({proposal}: AddressesListProps) {
     return (
       <Stack sx={{width: "100%"}} mt={4}>
         <Typography variant="h4" mb={4}>
-          You don't have a voting power for any staking pool address
+          We couldn't find any staking pool addresses, make sure you are
+          connected with your voter account.
         </Typography>
       </Stack>
     );

--- a/src/pages/Voting/index.tsx
+++ b/src/pages/Voting/index.tsx
@@ -1,9 +1,11 @@
 import {Grid} from "@mui/material";
-import {useParams} from "react-router-dom";
+import {useEffect} from "react";
+import {useNavigate, useParams} from "react-router-dom";
 
 import {useGetProposal} from "../../api/hooks/useGetProposal";
 import GoBack from "../../components/GoBack";
 import {IndividualPageHeader} from "../../components/Header";
+import {useWalletContext} from "../../context/wallet/context";
 import {EmptyProposal} from "../Proposal/EmptyProposal";
 import {ProposalHeader} from "../Proposal/Header";
 import AddressesList from "./components/AddressesList";
@@ -15,6 +17,14 @@ export type ProposalPageURLParams = {
 export default function Voting() {
   const {id: proposalId} = useParams() as ProposalPageURLParams;
   const proposal = useGetProposal(proposalId);
+  const {accountAddress, isConnected} = useWalletContext();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!accountAddress || !isConnected) {
+      navigate(`/proposal/${proposalId}`);
+    }
+  }, [accountAddress, isConnected]);
 
   if (!proposal) {
     return <EmptyProposal />;
@@ -27,7 +37,7 @@ export default function Voting() {
       <Grid item xs={12}>
         <ProposalHeader proposal={proposal} />
       </Grid>
-      <AddressesList proposal={proposal} />
+      <AddressesList proposal={proposal} accountAddress={accountAddress} />
     </Grid>
   );
 }

--- a/src/pages/Voting/index.tsx
+++ b/src/pages/Voting/index.tsx
@@ -1,14 +1,12 @@
 import {Grid} from "@mui/material";
-import {useState} from "react";
 import {useParams} from "react-router-dom";
+
 import {useGetProposal} from "../../api/hooks/useGetProposal";
 import GoBack from "../../components/GoBack";
 import {IndividualPageHeader} from "../../components/Header";
 import {EmptyProposal} from "../Proposal/EmptyProposal";
 import {ProposalHeader} from "../Proposal/Header";
-import {AddressToVoteMap} from "../Types";
 import AddressesList from "./components/AddressesList";
-import StakePoolAddressInput from "./components/StakePoolAddressInput";
 
 export type ProposalPageURLParams = {
   id: string;
@@ -17,8 +15,6 @@ export type ProposalPageURLParams = {
 export default function Voting() {
   const {id: proposalId} = useParams() as ProposalPageURLParams;
   const proposal = useGetProposal(proposalId);
-
-  const [addressVoteMap, setAddressVoteMap] = useState<AddressToVoteMap[]>();
 
   if (!proposal) {
     return <EmptyProposal />;
@@ -31,13 +27,7 @@ export default function Voting() {
       <Grid item xs={12}>
         <ProposalHeader proposal={proposal} />
       </Grid>
-      <StakePoolAddressInput
-        setAddressVoteMap={setAddressVoteMap}
-        proposalId={proposalId}
-      />
-      {addressVoteMap && (
-        <AddressesList addressVoteMap={addressVoteMap} proposal={proposal} />
-      )}
+      <AddressesList proposal={proposal} />
     </Grid>
   );
 }

--- a/src/pages/layout/index.tsx
+++ b/src/pages/layout/index.tsx
@@ -1,6 +1,8 @@
 import CssBaseline from "@mui/material/CssBaseline";
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
+import {GraphqlClientProvider} from "../../api/hooks/useGraphqlClient";
+
 import Header from "./Header";
 import Footer from "./Footer";
 import {GlobalStateProvider} from "../../context/globalState";
@@ -15,25 +17,28 @@ export default function GovernanceLayout({children}: LayoutProps) {
   return (
     <ProvideColorMode>
       <CssBaseline />
+
       <GlobalStateProvider>
-        <WalletProvider>
-          <Box
-            component="main"
-            sx={{
-              minHeight: "100vh",
-              backgroundColor: "transparent",
-              flexGrow: 1,
-              display: "flex",
-              flexDirection: "column",
-            }}
-          >
-            <Header />
-            <Container maxWidth="xl" sx={{flexGrow: 4, paddingTop: "2rem"}}>
-              {children}
-            </Container>
-            <Footer />
-          </Box>
-        </WalletProvider>
+        <GraphqlClientProvider>
+          <WalletProvider>
+            <Box
+              component="main"
+              sx={{
+                minHeight: "100vh",
+                backgroundColor: "transparent",
+                flexGrow: 1,
+                display: "flex",
+                flexDirection: "column",
+              }}
+            >
+              <Header />
+              <Container maxWidth="xl" sx={{flexGrow: 4, paddingTop: "2rem"}}>
+                {children}
+              </Container>
+              <Footer />
+            </Box>
+          </WalletProvider>
+        </GraphqlClientProvider>
       </GlobalStateProvider>
     </ProvideColorMode>
   );


### PR DESCRIPTION
uses indexer stake_pool <> voter mapping https://github.com/aptos-labs/aptos-core/pull/5215 so now we can fetch all staking pool addresses linked to a voter address.

On the voting page, fetch staking pool addresses by connected wallet account and populate on the page.
If no staking pool addresses - display a message saying no staking pool addresses found


https://user-images.githubusercontent.com/29798064/197586367-e8f0506f-41ae-4fcb-a80b-f0c0fc0ce8fc.mov




