### PR TITLE
convert OCTA num votes to APT

### DIFF
--- a/src/__tests__/utils.test.tsx
+++ b/src/__tests__/utils.test.tsx
@@ -1,0 +1,36 @@
+import {expect, it} from "@jest/globals";
+import {octaToAptString, octaToAptnFormatter} from "../utils";
+
+it("converts octa to apt correctly", () => {
+  expect(octaToAptString("0")).toEqual("0");
+  expect(octaToAptString("1")).toEqual("0.00000001");
+  expect(octaToAptString("100")).toEqual("0.000001");
+  expect(octaToAptString("10000")).toEqual("0.0001");
+  expect(octaToAptString("10000000")).toEqual("0.1");
+  expect(octaToAptString("100000000")).toEqual("1");
+  expect(octaToAptString("110000000")).toEqual("1.1");
+  expect(octaToAptString("110100000")).toEqual("1.1");
+  expect(octaToAptString("10000000000000000")).toEqual("100,000,000");
+  expect(octaToAptString("10000000000000001")).toEqual("100,000,000.");
+  expect(octaToAptString("1000200345670001")).toEqual("10,002,003.45");
+  expect(octaToAptString("1000200345000001")).toEqual("10,002,003.45");
+  expect(octaToAptString("100531551369517")).toEqual("1,005,315.51");
+  expect(octaToAptString("52431978984704074")).toEqual("524,319,789.84");
+});
+
+it("n formats octa to apt correctly", () => {
+  expect(octaToAptnFormatter("0")).toEqual("0");
+  expect(octaToAptnFormatter("1")).toEqual("0");
+  expect(octaToAptnFormatter("100")).toEqual("0");
+  expect(octaToAptnFormatter("10000")).toEqual("0");
+  expect(octaToAptnFormatter("10000000")).toEqual("0");
+  expect(octaToAptnFormatter("100000000")).toEqual("1");
+  expect(octaToAptnFormatter("110000000")).toEqual("1");
+  expect(octaToAptnFormatter("110100000")).toEqual("1");
+  expect(octaToAptnFormatter("52431978984704")).toEqual("524.3K");
+  expect(octaToAptnFormatter("10000000000000000")).toEqual("100M");
+  expect(octaToAptnFormatter("10000000000000001")).toEqual("100M");
+  expect(octaToAptnFormatter("1000200345670001")).toEqual("10M");
+  expect(octaToAptnFormatter("100531551369517")).toEqual("1M");
+  expect(octaToAptnFormatter("52431978984704074")).toEqual("524.3M");
+});

--- a/src/pages/Proposal/card/ResultBar.tsx
+++ b/src/pages/Proposal/card/ResultBar.tsx
@@ -7,12 +7,9 @@ import {
 } from "../../constants";
 import {useTheme} from "@mui/material/styles";
 import {grey} from "../../../themes/colors/aptosColorPalette";
+import {octaToAptString, octaToAptnFormatter} from "../../../utils";
 
 const RADIUS = "0.7em";
-
-function getFormattedVotesStr(votes: string): string {
-  return parseInt(votes).toLocaleString("en-US");
-}
 
 type ResultBarProps = {
   shouldPass: boolean;
@@ -33,14 +30,20 @@ export default function ResultBar({
   const remainingPercentageStr = `${(100 - percentage).toFixed(0)}%`;
 
   return (
-    <Tooltip title={`${getFormattedVotesStr(votes)} votes`} placement="left">
+    <Tooltip
+      title={`${octaToAptString(votes)} APT`}
+      placement="left"
+      arrow={true}
+    >
       <Stack>
         <Stack direction="row" justifyContent="space-between" paddingX={0.2}>
           <Typography variant="subtitle2" color={barColor}>
             {shouldPass ? voteFor : voteAgainst}
           </Typography>
 
-          <Typography variant="subtitle2">{percentageStr}</Typography>
+          <Typography variant="subtitle2">
+            {`${octaToAptnFormatter(votes)} APT`} {percentageStr}
+          </Typography>
         </Stack>
         <Stack direction="row">
           <Box

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,3 +21,103 @@ export function hex_to_string(hex: string): string {
   }
   return str;
 }
+
+function getFormattedVotesStr(votes: string): string {
+  return parseInt(votes).toLocaleString("en-US");
+}
+
+const APTOS_DECIMALS = 8;
+const FIXED_DECIMAL_PLACES = 2;
+
+function trimRight(rightSide: string) {
+  while (rightSide.endsWith("0")) {
+    rightSide = rightSide.slice(0, -1);
+  }
+  return rightSide;
+}
+/*
+Converts OCTA to APT and returns APT as string representation 
+*/
+export function octaToAptString(amount: string, decimals?: number): string {
+  // If it's zero, just return it
+  if (amount == "0") {
+    return amount;
+  }
+
+  const len = amount.length;
+  decimals = decimals || APTOS_DECIMALS;
+
+  // If length is less than decimals, pad with 0s to decimals length and return
+  if (len <= decimals) {
+    return "0." + (trimRight("0".repeat(decimals - len) + amount) || "0");
+  }
+
+  // Otherwise, insert decimal point at len - decimals
+  const leftSide = BigInt(amount.slice(0, len - decimals)).toLocaleString(
+    "en-US",
+  );
+  let rightSide = amount.slice(len - decimals);
+  if (BigInt(rightSide) == BigInt(0)) {
+    return leftSide;
+  }
+
+  // remove trailing 0s
+  rightSide = trimRight(rightSide);
+
+  if (FIXED_DECIMAL_PLACES && rightSide.length > FIXED_DECIMAL_PLACES) {
+    rightSide = rightSide.slice(0, FIXED_DECIMAL_PLACES - rightSide.length);
+  }
+
+  return leftSide + "." + trimRight(rightSide);
+}
+
+/*
+Converts OCTA to APT and returns APT as n formatted string representation 
+52431978984704 OCTA -> 524.3K APT
+*/
+export function octaToAptnFormatter(amount: string, decimals?: number): string {
+  // If length is less than decimals or it's zero, return 0
+  const len = amount.length;
+  decimals = decimals || APTOS_DECIMALS;
+  if (len <= decimals || amount == "0") {
+    return nFormatter(0);
+  }
+
+  // insert decimal point at len - decimals
+  const leftSide = BigInt(amount.slice(0, len - decimals));
+  let rightSide = amount.slice(len - decimals);
+  if (BigInt(rightSide) == BigInt(0)) {
+    return nFormatter(Number(leftSide));
+  }
+
+  // remove trailing 0s
+  rightSide = trimRight(rightSide);
+
+  if (FIXED_DECIMAL_PLACES && rightSide.length > FIXED_DECIMAL_PLACES) {
+    rightSide = rightSide.slice(0, FIXED_DECIMAL_PLACES - rightSide.length);
+  }
+
+  return nFormatter(parseInt(leftSide + "." + trimRight(rightSide)));
+}
+
+function nFormatter(num: number) {
+  const lookup = [
+    {value: 1, symbol: ""},
+    {value: 1e3, symbol: "K"},
+    {value: 1e6, symbol: "M"},
+    {value: 1e9, symbol: "G"},
+    {value: 1e12, symbol: "T"},
+    {value: 1e15, symbol: "P"},
+    {value: 1e18, symbol: "E"},
+  ];
+  const rx = /\.0+$|(\.[0-9]*[1-9])0+$/;
+  var item = lookup
+    .slice()
+    .reverse()
+    .find(function (item) {
+      return num >= item.value;
+    });
+  return item
+    ? (num / item.value).toFixed(1).replace(rx, "$1") + item.symbol
+    : "0";
+}


### PR DESCRIPTION
Show the vote amount in APT, and show it directly on the page without the user needing to hover on the label 

On this example, the num votes in OCTA is 52431978984704074

<img width="705" alt="Screen Shot 2022-10-27 at 1 06 13 PM" src="https://user-images.githubusercontent.com/29798064/198387754-8c81f6eb-36c2-4fbb-8a98-d4e2e1f0a464.png">
