### PR TITLE
fix metadata key searching

### DIFF
--- a/src/api/hooks/useGetProposal.tsx
+++ b/src/api/hooks/useGetProposal.tsx
@@ -47,7 +47,11 @@ const fetchProposalMetadata = async (
   proposalData: Proposal,
 ): Promise<ProposalMetadata | null> => {
   // fetch proposal metadata from metadata_location property
-  const metadata_location = hex_to_string(proposalData.metadata.data[1].value);
+  const proposal_metadata_location = proposalData.metadata.data.find(
+    (metadata) => metadata.key === "metadata_location",
+  )!.value;
+  const metadata_location = hex_to_string(proposal_metadata_location);
+
   const raw_metadata_location = getRawGithubUrl(metadata_location);
 
   const response = await fetch(raw_metadata_location);
@@ -57,7 +61,9 @@ const fetchProposalMetadata = async (
   const metadataText = await response.text();
 
   //validate metadata
-  const metadata_hash = proposalData.metadata.data[0].value;
+  const metadata_hash = proposalData.metadata.data.find(
+    (metadata) => metadata.key === "metadata_hash",
+  )!.value;
 
   const hash = sha3_256(metadataText);
   if (hex_to_string(metadata_hash) !== hash) return null;


### PR DESCRIPTION
All proposals we are getting back have this metadata structure
```
metadata: {
    data: [
      {
        key: "metadata_hash";
        value: string;
      },
      {
        key: "metadata_location";
        value: string;
      },
    ];
  };
```
but when a proposal has this structure
```
metadata: {
    data: [
      {
        key: "metadata_location";
        value: string;
      },
      {
        key: "metadata_hash";
        value: string;
      },
    ];
  };
```
we end up with a wrong parsing here https://github.com/aptos-labs/governance/blob/main/src/utils.ts#L15
because we are getting the metadata_location by a hardcoded array index https://github.com/aptos-labs/governance/blob/main/src/api/hooks/useGetProposal.tsx#L50

**Fix**
This PR changes the logic to search for the specific key in the metadata array.

https://aptos-org.slack.com/archives/C03RGDZ658X/p1676997000918909