### PR TITLE
refactor the governance site landing page

### DIFF
--- a/src/components/GeneralTableHeaderCell.tsx
+++ b/src/components/GeneralTableHeaderCell.tsx
@@ -1,12 +1,22 @@
-import {Typography, TableCell, useTheme, Stack} from "@mui/material";
+import {
+  Typography,
+  TableCell,
+  useTheme,
+  Stack,
+  TableSortLabel,
+} from "@mui/material";
 import {SxProps} from "@mui/system";
 import {Theme} from "@mui/material/styles";
+import SouthIcon from "@mui/icons-material/South";
 
 interface GeneralTableHeaderCellProps {
   header: React.ReactNode;
   textAlignRight?: boolean;
   sx?: SxProps<Theme>;
   tooltip?: React.ReactNode;
+  sortable?: boolean;
+  direction?: "desc" | "asc";
+  selectAndSetDirection?: (dir: "desc" | "asc") => void;
 }
 
 export default function GeneralTableHeaderCell({
@@ -14,11 +24,40 @@ export default function GeneralTableHeaderCell({
   textAlignRight,
   sx = [],
   tooltip,
+  sortable,
+  direction,
+  selectAndSetDirection,
 }: GeneralTableHeaderCellProps) {
   const theme = useTheme();
   const tableCellBackgroundColor = "transparent";
   const tableCellTextColor = theme.palette.text.secondary;
 
+  const toggleDirection = () => {
+    if (selectAndSetDirection === undefined) {
+      return;
+    }
+    selectAndSetDirection(direction === "desc" ? "asc" : "desc");
+  };
+
+  const headerSortLabel = sortable ? (
+    <TableSortLabel
+      active={direction !== undefined}
+      direction={direction === undefined ? "desc" : direction}
+      onClick={toggleDirection}
+      IconComponent={SouthIcon}
+      sx={{
+        "&.MuiTableSortLabel-root .MuiTableSortLabel-icon": {
+          marginLeft: 0,
+          marginRight: 0.5,
+        },
+        flexDirection: "row-reverse",
+      }}
+    >
+      {header}
+    </TableSortLabel>
+  ) : (
+    header
+  );
   return (
     <TableCell
       sx={[
@@ -36,11 +75,11 @@ export default function GeneralTableHeaderCell({
           spacing={1}
           justifyContent={textAlignRight ? "flex-end" : "flex-start"}
         >
-          <Typography variant="subtitle1">{header}</Typography>
+          <Typography variant="subtitle1">{headerSortLabel}</Typography>
           {tooltip}
         </Stack>
       ) : (
-        <Typography variant="subtitle1">{header}</Typography>
+        <Typography variant="subtitle1">{headerSortLabel}</Typography>
       )}
     </TableCell>
   );

--- a/src/pages/LandingPage/Header.tsx
+++ b/src/pages/LandingPage/Header.tsx
@@ -1,4 +1,4 @@
-import {Button, Grid, Typography} from "@mui/material";
+import {Button, Grid, Link, Typography} from "@mui/material";
 import {Box} from "@mui/system";
 
 type HeaderProps = {
@@ -18,14 +18,24 @@ export const Header = ({onVoteProposalButtonClick}: HeaderProps) => {
           <Grid item xs={12} sm={6}>
             <Typography variant="h6">
               Welcome to Aptos Governance. Here you can view and vote on the
-              proposals.
+              proposals. Learn more about Aptos Governance{" "}
+              <Link
+                href="https://aptos.dev/concepts/governance/"
+                target="_blank"
+                title="Aptos Foundation"
+              >
+                here
+              </Link>
+              .
             </Typography>
           </Grid>
           <Grid item xs={12} sm={6}>
             <Typography variant="body1" mb={4}>
-              To view proposals, click the View Proposals below. To vote on a
-              proposal, install Petra (Aptos Wallet), connect to the wallet and
-              begin voting on any proposal. You can vote on multiple proposals.
+              Aptos Governance is where on chain voting occurs for AIPs (Aptos
+              Improvement Proposals). To vote on a proposal, install Petra
+              (Aptos Wallet), connect to the wallet and begin voting on any
+              proposal. You can vote on multiple proposals. You can view all
+              AIPs here.
             </Typography>
             <Box justifyContent="center">
               <Button
@@ -33,7 +43,7 @@ export const Header = ({onVoteProposalButtonClick}: HeaderProps) => {
                 onClick={onVoteProposalButtonClick}
                 sx={{width: "300px"}}
               >
-                View Proposals
+                View AIPs
               </Button>
             </Box>
           </Grid>


### PR DESCRIPTION
https://aptos-org.slack.com/archives/C04AF485ZFV/p1684327554395399?thread_ts=1684325514.823999&cid=C04AF485ZFV

## changes
1. make table sortable, default to be desc order for proposal starts date
2. update some contents

<img width="1712" alt="Screenshot 2023-05-17 at 8 05 58 PM" src="https://github.com/aptos-labs/governance/assets/121921928/c1d75a49-eb30-4780-86b0-941e3cd4422d">
