### PR TITLE
Update Discord URL in footer

### DIFF
--- a/src/pages/layout/Footer.tsx
+++ b/src/pages/layout/Footer.tsx
@@ -19,7 +19,7 @@ const socialLinks = [
   },
   {
     title: "Discord",
-    url: "https://discord.com/invite/aptoslabs",
+    url: "https://discord.com/invite/aptosnetwork",
     icon: DiscordLogo,
   },
   {


### PR DESCRIPTION
Update the Discord URL within social icon in footer to https://discord.com/invite/aptosnetwork