### PR TITLE
Update error message

### DIFF
--- a/src/pages/Voting/components/AddressesList.tsx
+++ b/src/pages/Voting/components/AddressesList.tsx
@@ -163,7 +163,8 @@ export default function AddressesList({
       <Stack sx={{width: "100%"}} mt={4}>
         <Typography variant="h4" mb={4}>
           We couldn't find any staking pool addresses, make sure you are
-          connected with your voter account.
+          connected with your voter account. If you're delegated staking
+          user, use https://govscan.live/aptos/proposals to vote instead.
         </Typography>
       </Stack>
     );


### PR DESCRIPTION
Governance tool does not support delegated staking, direct user to govscan instead.