### PR TITLE
[frontend] add error msgs + loader

### DIFF
--- a/src/api/hooks/useGetProposal.tsx
+++ b/src/api/hooks/useGetProposal.tsx
@@ -2,11 +2,12 @@ import {useEffect, useState} from "react";
 import {sha3_256} from "js-sha3";
 
 import {getTableItem} from "..";
-import {Proposal, ProposalMetadata} from "../../pages/Types";
+import {Proposal, ProposalMetadata, ProposalError} from "../../pages/Types";
 import {hex_to_string} from "../../utils";
 import {getProposalStatus, isVotingClosed} from "../../pages/utils";
 import {useGetProposalsTableData} from "../hooks/useGetProposalsTableData";
 import {GlobalState, useGlobalState} from "../../context/globalState/context";
+import {defaultProposalErrorMessage} from "../../constants";
 
 const fetchTableItem = async (
   proposal_id: string,
@@ -45,7 +46,7 @@ const getRawGithubUrl = (url: string): string => {
 
 const fetchProposalMetadata = async (
   proposalData: Proposal,
-): Promise<ProposalMetadata | null> => {
+): Promise<ProposalMetadata | ProposalError> => {
   // fetch proposal metadata from metadata_location property
   const proposal_metadata_location = proposalData.metadata.data.find(
     (metadata) => metadata.key === "metadata_location",
@@ -56,20 +57,25 @@ const fetchProposalMetadata = async (
 
   const response = await fetch(raw_metadata_location);
   // validate response status
-  if (response.status !== 200) return null;
+  if (response.status !== 200) {
+    return {
+      errorMessage: "Proposal metadata not found",
+    };
+  }
 
   const metadataText = await response.text();
-
-  //validate metadata
+  // validate metadata
   const metadata_hash = proposalData.metadata.data.find(
     (metadata) => metadata.key === "metadata_hash",
   )!.value;
-
   const hash = sha3_256(metadataText);
-  if (hex_to_string(metadata_hash) !== hash) return null;
+  if (hex_to_string(metadata_hash) !== hash) {
+    return {
+      errorMessage: "Metadata is invalid",
+    };
+  }
 
   const proposal_metadata = JSON.parse(metadataText);
-
   return proposal_metadata;
 };
 
@@ -77,15 +83,24 @@ const fetchProposal = async (
   proposal_id: string,
   handle: string,
   state: GlobalState,
-): Promise<Proposal | null> => {
+): Promise<Proposal | ProposalError> => {
   // fetch proposal table item
   const proposalData = await fetchTableItem(proposal_id, handle, state);
-  if (!proposalData) return null;
+  if (!proposalData) {
+    return {
+      errorMessage: defaultProposalErrorMessage,
+    };
+  }
 
   // fetch proposal metadata
   const proposal_metadata = await fetchProposalMetadata(proposalData);
   // if bad metadata response or metadata hash is different
-  if (!proposal_metadata) return null;
+  if ("errorMessage" in proposal_metadata) {
+    return {
+      errorMessage:
+        proposal_metadata.errorMessage ?? defaultProposalErrorMessage,
+    };
+  }
 
   proposalData.status = getProposalStatus(proposalData);
   proposalData.is_voting_closed = isVotingClosed(proposalData);
@@ -96,19 +111,25 @@ const fetchProposal = async (
   return proposalData;
 };
 
-export function useGetProposal(proposal_id: string): Proposal | undefined {
+export function useGetProposal(proposal_id: string): {
+  proposal: Proposal | ProposalError | undefined;
+  loading: boolean;
+} {
   const [state, _setState] = useGlobalState();
-  const [proposal, setProposal] = useState<Proposal>();
+  const [proposal, setProposal] = useState<Proposal | ProposalError>();
+  const [loading, setLoading] = useState(true);
   const proposalTableData = useGetProposalsTableData();
 
   const handle = proposalTableData?.handle ?? undefined;
   useEffect(() => {
     if (handle !== undefined) {
+      setLoading(true);
       fetchProposal(proposal_id, handle, state).then((data) => {
         data && setProposal(data);
+        setLoading(false);
       });
     }
   }, [handle, state]);
 
-  return proposal;
+  return {proposal, loading};
 }

--- a/src/api/hooks/useGetProposal.tsx
+++ b/src/api/hooks/useGetProposal.tsx
@@ -71,7 +71,7 @@ const fetchProposalMetadata = async (
   const hash = sha3_256(metadataText);
   if (hex_to_string(metadata_hash) !== hash) {
     return {
-      errorMessage: "Metadata is invalid",
+      errorMessage: "Metadata hash mismatch",
     };
   }
 

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -62,3 +62,5 @@ export const installWalletUrl =
   "https://chrome.google.com/webstore/detail/petra-aptos-wallet/ejjladinnckdgjemekebdpeokbikhfci";
 
 export const explorerUrl = "https://explorer.aptoslabs.com";
+
+export const defaultProposalErrorMessage = "Proposal not found";

--- a/src/pages/LandingPage/Table.tsx
+++ b/src/pages/LandingPage/Table.tsx
@@ -130,14 +130,14 @@ type ProposalRowProps = {
 };
 
 function ProposalRow({proposal_id, columns}: ProposalRowProps) {
-  const proposalData = useGetProposal(proposal_id);
+  const {proposal: proposalData} = useGetProposal(proposal_id);
   const navigate = RRD.useNavigate();
 
   const onTableRowClick = () => {
     navigate(`/proposal/${proposal_id}`);
   };
 
-  if (!proposalData) {
+  if (!proposalData || "errorMessage" in proposalData) {
     // returns null as we don't need to generate a TableRow if there is no proposal data
     return null;
   }
@@ -226,8 +226,9 @@ export function ProposalsTable({
   // TODO - future improvement, once more proposals, show 10 proposals on homepage
   // and the rest on the Ptoposals page.
   const counter = parseInt(nextProposalId);
-  const proposalRows = Array.from({length: counter}, (_, proposal_id) =>
-    useGetProposal(proposal_id.toString()),
+  const proposalRows = Array.from(
+    {length: counter},
+    (_, proposal_id) => useGetProposal(proposal_id.toString()).proposal,
   ).filter((proposal) => proposal !== undefined) as Proposal[];
 
   const [sortColumn, setSortColumn] =

--- a/src/pages/Proposal/EmptyProposal.tsx
+++ b/src/pages/Proposal/EmptyProposal.tsx
@@ -1,10 +1,10 @@
 import {Grid} from "@mui/material";
 
 // TODO: generalize empty page for proposals, transactions, and more
-export function EmptyProposal() {
+export function EmptyProposal({errorMessage}: {errorMessage: string}) {
   return (
     <Grid container marginTop={{md: 12, xs: 6}}>
-      PROPOSAL NOT FOUND
+      {errorMessage.toUpperCase()}
     </Grid>
   );
 }

--- a/src/pages/Types.ts
+++ b/src/pages/Types.ts
@@ -34,6 +34,10 @@ export type Proposal = {
   status: ProposalStatus; // represents general proposal status
 };
 
+export type ProposalError = {
+  errorMessage: string;
+};
+
 export type ProposalMetadata = {
   title: string;
   description: string;

--- a/src/pages/Voting/index.tsx
+++ b/src/pages/Voting/index.tsx
@@ -9,6 +9,7 @@ import {useWalletContext} from "../../context/wallet/context";
 import {EmptyProposal} from "../Proposal/EmptyProposal";
 import {ProposalHeader} from "../Proposal/Header";
 import AddressesList from "./components/AddressesList";
+import {defaultProposalErrorMessage} from "../../constants";
 
 export type ProposalPageURLParams = {
   id: string;
@@ -16,7 +17,7 @@ export type ProposalPageURLParams = {
 
 export default function Voting() {
   const {id: proposalId} = useParams() as ProposalPageURLParams;
-  const proposal = useGetProposal(proposalId);
+  const {proposal} = useGetProposal(proposalId);
   const {accountAddress, isConnected} = useWalletContext();
   const navigate = useNavigate();
 
@@ -26,8 +27,12 @@ export default function Voting() {
     }
   }, [accountAddress, isConnected]);
 
-  if (!proposal) {
-    return <EmptyProposal />;
+  if (!proposal || "errorMessage" in proposal) {
+    return (
+      <EmptyProposal
+        errorMessage={proposal?.errorMessage ?? defaultProposalErrorMessage}
+      />
+    );
   }
 
   return (

--- a/src/pages/VotingStatus/index.tsx
+++ b/src/pages/VotingStatus/index.tsx
@@ -9,6 +9,7 @@ import {ProposalHeader} from "../Proposal/Header";
 import {AddressToVoteMap} from "../Types";
 import AddressesList from "./components/AddressesList";
 import StakePoolAddressInput from "./components/StakePoolAddressInput";
+import {defaultProposalErrorMessage} from "../../constants";
 
 export type ProposalPageURLParams = {
   id: string;
@@ -16,12 +17,16 @@ export type ProposalPageURLParams = {
 
 export default function VotingStatus() {
   const {id: proposalId} = useParams() as ProposalPageURLParams;
-  const proposal = useGetProposal(proposalId);
+  const {proposal} = useGetProposal(proposalId);
 
   const [addressVoteMap, setAddressVoteMap] = useState<AddressToVoteMap[]>();
 
-  if (!proposal) {
-    return <EmptyProposal />;
+  if (!proposal || "errorMessage" in proposal) {
+    return (
+      <EmptyProposal
+        errorMessage={proposal?.errorMessage ?? defaultProposalErrorMessage}
+      />
+    );
   }
 
   return (


### PR DESCRIPTION
## Description
- relevant slack threads: https://aptos-org.slack.com/archives/C03RGDZ658X/p1728071717317759, https://aptos-org.slack.com/archives/C03RGDZ658X/p1728071839845759
- there were not very descriptive error messages for what was failing in proposal data fetching
  - i.e. `Proposal not found` for everything
- also, `Proposal not found` would flash while proposal data was fetching

Added:
- some error messages for metadata errors
- loading state when fetching proposals

---
Before:

https://github.com/user-attachments/assets/49bf0ddd-0e0f-439b-93fe-27ddd3895337

After:

https://github.com/user-attachments/assets/35a258d8-4e57-4a69-aa19-7d9e691357f4
