### PR TITLE
Use Aptos Build API keys

### DIFF
--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -1,0 +1,27 @@
+import {AptosClient} from "aptos";
+
+/**
+ * Use this function to get the config for the AptosClient. To avoid having to change
+ * the code too much, we derive which network we're dealing with by looking at the
+ * URL for the node API (rather than passing around a `Network`).
+ */
+export function getConfig(
+  network_value: string,
+): ConstructorParameters<typeof AptosClient>[1] {
+  return {
+    TOKEN: getApiKey(network_value),
+  };
+}
+
+function getApiKey(network_value: string): string | undefined {
+  if (network_value.includes("mainnet")) {
+    return "AG-JJUCSHK3XMWV3XFNH7LZ7AMPCKYDLWW9Y";
+  }
+  if (network_value.includes("testnet")) {
+    return "AG-KMOTRHDA8GPQHMT9NNEF5NK1ONSRV327V";
+  }
+  if (network_value.includes("devnet")) {
+    return "AG-HR9VQNGZFUEKBCPWMH1OXC669PEXDZB3O";
+  }
+  return undefined;
+}

--- a/src/api/hooks/useSubmitTransaction.ts
+++ b/src/api/hooks/useSubmitTransaction.ts
@@ -5,6 +5,7 @@ import {useWalletContext} from "../../context/wallet/context";
 import {signAndSubmitTransaction} from "../wallet";
 import {useGlobalState} from "../../context/globalState";
 import {networks} from "../../constants";
+import {getConfig} from "../common";
 
 export type TransactionResponse =
   | TransactionResponseOnSubmission
@@ -29,9 +30,10 @@ const useSubmitTransaction = () => {
     useState<boolean>(false);
   const [state, _] = useGlobalState();
   const {walletNetwork} = useWalletContext();
-  const client = new AptosClient(state.network_value, {
-    WITH_CREDENTIALS: false,
-  });
+  const client = new AptosClient(
+    state.network_value,
+    getConfig(state.network_value),
+  );
 
   useEffect(() => {
     if (transactionResponse !== null) {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,17 +1,7 @@
 import {AptosClient, MaybeHexString, Types} from "aptos";
 import {isHex} from "../pages/utils";
 import {withResponseError} from "./client";
-
-/**
- * AptosClient 1.3.8+ added a feature to fix the sticky session problem.
- * Client requests might be routed to different fullnodes by load balancer, so the data read by clients might be inconsistent.
- * Load balancer uses cookie for sticky session. Therefore clients need to carry cookie.
- *
- * Unfortunately, this new feature would cause CORS issue for testnet and local networks.
- * While waiting for the testnet nodes upgrading to the latest software,
- * we apply this walk-around to make WITH_CREDENTIALS false when creating AptosClients.
- */
-const config = {WITH_CREDENTIALS: false};
+import {getConfig} from "./common";
 
 export function getTransaction(
   requestParameters: {txnHashOrVersion: string | number},
@@ -29,7 +19,7 @@ function getTransactionByVersion(
   version: number,
   nodeUrl: string,
 ): Promise<Types.Transaction> {
-  const client = new AptosClient(nodeUrl, config);
+  const client = new AptosClient(nodeUrl, getConfig(nodeUrl));
   return withResponseError(client.getTransactionByVersion(BigInt(version)));
 }
 
@@ -37,7 +27,7 @@ function getTransactionByHash(
   hash: string,
   nodeUrl: string,
 ): Promise<Types.Transaction> {
-  const client = new AptosClient(nodeUrl, config);
+  const client = new AptosClient(nodeUrl, getConfig(nodeUrl));
   return withResponseError(client.getTransactionByHash(hash));
 }
 
@@ -45,7 +35,7 @@ export function getAccount(
   requestParameters: {address: string},
   nodeUrl: string,
 ): Promise<Types.AccountData> {
-  const client = new AptosClient(nodeUrl, config);
+  const client = new AptosClient(nodeUrl, getConfig(nodeUrl));
   const {address} = requestParameters;
   return withResponseError(client.getAccount(address));
 }
@@ -54,7 +44,7 @@ export function getAccountResources(
   requestParameters: {address: MaybeHexString; ledgerVersion?: number},
   nodeUrl: string,
 ): Promise<Types.MoveResource[]> {
-  const client = new AptosClient(nodeUrl, config);
+  const client = new AptosClient(nodeUrl, getConfig(nodeUrl));
   const {address, ledgerVersion} = requestParameters;
   let ledgerVersionBig;
   if (ledgerVersion) {
@@ -73,7 +63,7 @@ export function getAccountResource(
   },
   nodeUrl: string,
 ): Promise<Types.MoveResource> {
-  const client = new AptosClient(nodeUrl, config);
+  const client = new AptosClient(nodeUrl, getConfig(nodeUrl));
   const {address, resourceType, ledgerVersion} = requestParameters;
   let ledgerVersionBig;
   if (ledgerVersion) {
@@ -90,7 +80,7 @@ export function getAccountModules(
   requestParameters: {address: string; ledgerVersion?: number},
   nodeUrl: string,
 ): Promise<Types.MoveModuleBytecode[]> {
-  const client = new AptosClient(nodeUrl, config);
+  const client = new AptosClient(nodeUrl, getConfig(nodeUrl));
   const {address, ledgerVersion} = requestParameters;
   let ledgerVersionBig;
   if (ledgerVersion) {
@@ -105,7 +95,7 @@ export function getTableItem(
   requestParameters: {tableHandle: string; data: Types.TableItemRequest},
   nodeUrl: string,
 ): Promise<any> {
-  const client = new AptosClient(nodeUrl, config);
+  const client = new AptosClient(nodeUrl, getConfig(nodeUrl));
   const {tableHandle, data} = requestParameters;
   return withResponseError(client.getTableItem(tableHandle, data));
 }

--- a/src/context/globalState/context.tsx
+++ b/src/context/globalState/context.tsx
@@ -16,6 +16,7 @@ function safeGetSelectedNetworkName(): NetworkName {
 
 export type GlobalState = {
   network_name: NetworkName;
+  /** Despite the name this is a node API URL. */
   network_value: string;
 };
 

--- a/src/pages/CreateProposal/Create.tsx
+++ b/src/pages/CreateProposal/Create.tsx
@@ -4,6 +4,7 @@ import {AptosClient, AptosAccount, FaucetClient, HexString, Types} from "aptos";
 import {getHexString} from "../utils";
 import {useGlobalState} from "../../context/globalState";
 import {doTransaction} from "../utils";
+import {getConfig} from "../../api/common";
 
 /* REQUIRED: Please replace the following with your own local network urls */
 const FAUCET_URL = "http://127.0.0.1:80";
@@ -53,9 +54,10 @@ export function Create() {
   };
 
   const onCreateProposalClick = async () => {
-    const client = new AptosClient(state.network_value, {
-      WITH_CREDENTIALS: false,
-    });
+    const client = new AptosClient(
+      state.network_value,
+      getConfig(state.network_value),
+    );
     const faucetClient = new FaucetClient(
       state.network_value,
       FAUCET_URL,

--- a/src/pages/Voting/components/AddressesList.tsx
+++ b/src/pages/Voting/components/AddressesList.tsx
@@ -163,8 +163,8 @@ export default function AddressesList({
       <Stack sx={{width: "100%"}} mt={4}>
         <Typography variant="h4" mb={4}>
           We couldn't find any staking pool addresses, make sure you are
-          connected with your voter account. If you're delegated staking
-          user, use https://govscan.live/aptos/proposals to vote instead.
+          connected with your voter account. If you're delegated staking user,
+          use https://govscan.live/aptos/proposals to vote instead.
         </Typography>
       </Stack>
     );


### PR DESCRIPTION
## Summary
Currently all the API requests on the governance site get 429'd quite quickly due to the new lower anonymous API limits. In this PR I make the site use API keys.

I also unset the `WITH_CREDENTIALS: false` thing here, it is no longer necessary, we needed it due to a very ancient issue with the node API rejecting headers erroneously I believe.

## Test Plan
See from using the preview that an API key is included in requests now and you don't get 429s now. I tested this for mainnet. If you select testnet the site crashes, but this was already the case and isn't in scope for this PR.