### PR TITLE
Handle ProposalError case gracefully in ProposalsTable

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
## Summary
The original code was erroneously always casting proposal rows to Proposal, even when sometimes there might be a ProposalError. This PR changes that so we correctly handle that case and filter out those rows, rather than just crashing the whole site.

This PR doesn't do anything to figure out why those two proposals failed to load in the first place, that can come separately.

## Test Plan
<img width="1445" alt="image" src="https://github.com/user-attachments/assets/b2baccc6-e058-4103-b272-5a7d0f34b508" />
