### PR TITLE
Fix horizontal overflow of proposals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ dist/
 .env
 .env.local
 .DS_Store
+tests/e2e/artifacts/
+test-results/
+playwright-report/
+
+

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -11,13 +11,13 @@ export function PageHeader({
   return (
     <>
       <div className="grid items-center gap-4 sm:grid-cols-2">
-        <div>
+        <div className="min-w-0">
           {subtitle ? (
             <>
               <p className="mb-1 text-base font-normal uppercase leading-tight tracking-wide text-[var(--color-primary)]">
                 {subtitle}
               </p>
-              <h1 className="text-6xl font-light tracking-tight sm:text-7xl lg:text-[6rem]">
+              <h1 className="break-words text-4xl font-light tracking-tight sm:text-6xl lg:text-[6rem]">
                 {title}
               </h1>
             </>

--- a/src/components/ProposalsTable.tsx
+++ b/src/components/ProposalsTable.tsx
@@ -116,9 +116,13 @@ function ProposalRow({
       <td>
         <AddressChip address={proposal.proposer} />
       </td>
-      <td>{formatTimestamp(proposal.creationTimeSecs)}</td>
-      <td>{formatTimestamp(proposal.expirationSecs)}</td>
-      <td className="text-right">
+      <td className="gov-table-wrap">
+        {formatTimestamp(proposal.creationTimeSecs)}
+      </td>
+      <td className="gov-table-wrap">
+        {formatTimestamp(proposal.expirationSecs)}
+      </td>
+      <td className="gov-table-wrap text-right">
         {formatTimestamp(proposal.resolutionTimeSecs)}
       </td>
     </tr>

--- a/src/components/ProposalsTable.tsx
+++ b/src/components/ProposalsTable.tsx
@@ -1,9 +1,26 @@
-import {useNavigate} from "@tanstack/react-router";
+import {Link, useNavigate} from "@tanstack/react-router";
 import {AddressChip} from "~/components/AddressChip";
 import {MyVoteBadge} from "~/components/MyVoteBadge";
 import {StatusLabel} from "~/components/StatusIcon";
-import {formatTimestamp} from "~/lib/governance/format";
+import {formatTimestamp, truncateAddress} from "~/lib/governance/format";
 import type {ProposalListItem} from "~/lib/governance/types";
+
+function proposalTitle(proposal: ProposalListItem): string {
+  return proposal.metadataResult.verified
+    ? proposal.metadataResult.metadata.title
+    : `Proposal #${proposal.proposalId}`;
+}
+
+function UnverifiedNote({reason}: {reason: string}) {
+  return (
+    <p
+      className="mt-0.5 truncate text-xs font-semibold text-[var(--color-error)]"
+      title={reason}
+    >
+      Metadata unverified
+    </p>
+  );
+}
 
 export function ProposalsTable({
   proposals,
@@ -13,29 +30,48 @@ export function ProposalsTable({
   myVotes?: Record<string, {shouldPass: boolean}>;
 }) {
   return (
-    <div className="w-auto overflow-x-auto">
-      <table className="gov-table min-w-full text-sm">
-        <thead>
-          <tr className="text-left">
-            <th>Title</th>
-            <th>Status</th>
-            <th>Proposer</th>
-            <th>Voting Start Date</th>
-            <th>Voting End Date</th>
-            <th className="text-right">Execution Date</th>
-          </tr>
-        </thead>
-        <tbody>
-          {proposals.map((proposal) => (
-            <ProposalRow
-              key={proposal.proposalId}
-              proposal={proposal}
-              myVote={myVotes?.[proposal.proposalId]}
-            />
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <>
+      <div data-testid="proposals-table" className="hidden w-full xl:block">
+        <table className="gov-table w-full table-fixed text-sm">
+          <colgroup>
+            <col className="w-[30%]" />
+            <col className="w-[18%]" />
+            <col className="w-[16%]" />
+            <col className="w-[12%]" />
+            <col className="w-[12%]" />
+            <col className="w-[12%]" />
+          </colgroup>
+          <thead>
+            <tr className="text-left">
+              <th>Title</th>
+              <th>Status</th>
+              <th>Proposer</th>
+              <th>Voting Start Date</th>
+              <th>Voting End Date</th>
+              <th className="text-right">Execution Date</th>
+            </tr>
+          </thead>
+          <tbody>
+            {proposals.map((proposal) => (
+              <ProposalRow
+                key={proposal.proposalId}
+                proposal={proposal}
+                myVote={myVotes?.[proposal.proposalId]}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div data-testid="proposals-mobile-list" className="space-y-3 xl:hidden">
+        {proposals.map((proposal) => (
+          <ProposalMobileCard
+            key={proposal.proposalId}
+            proposal={proposal}
+            myVote={myVotes?.[proposal.proposalId]}
+          />
+        ))}
+      </div>
+    </>
   );
 }
 
@@ -47,9 +83,7 @@ function ProposalRow({
   myVote?: {shouldPass: boolean};
 }) {
   const navigate = useNavigate();
-  const title = proposal.metadataResult.verified
-    ? proposal.metadataResult.metadata.title
-    : `Proposal #${proposal.proposalId}`;
+  const title = proposalTitle(proposal);
 
   return (
     <tr
@@ -61,13 +95,20 @@ function ProposalRow({
         })
       }
     >
-      <td className="max-w-[400px]">
-        <div className="flex items-center gap-2">
-          <span className="block max-w-[400px] truncate font-normal text-[var(--color-title)]">
+      <td>
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="min-w-0 truncate font-normal text-[var(--color-title)]">
             {title}
           </span>
-          {myVote && <MyVoteBadge shouldPass={myVote.shouldPass} />}
+          {myVote && (
+            <span className="shrink-0">
+              <MyVoteBadge shouldPass={myVote.shouldPass} />
+            </span>
+          )}
         </div>
+        {!proposal.metadataResult.verified && (
+          <UnverifiedNote reason={proposal.metadataResult.reason} />
+        )}
       </td>
       <td>
         <StatusLabel status={proposal.status} />
@@ -81,5 +122,74 @@ function ProposalRow({
         {formatTimestamp(proposal.resolutionTimeSecs)}
       </td>
     </tr>
+  );
+}
+
+function ProposalMobileCard({
+  proposal,
+  myVote,
+}: {
+  proposal: ProposalListItem;
+  myVote?: {shouldPass: boolean};
+}) {
+  const title = proposalTitle(proposal);
+
+  return (
+    <Link
+      to="/proposal/$proposalId"
+      params={{proposalId: proposal.proposalId}}
+      search={{votesPage: 0}}
+      className="block rounded-lg bg-[var(--color-paper)] p-4"
+    >
+      <div className="flex items-start gap-2">
+        <h3 className="min-w-0 flex-1 truncate font-normal text-[var(--color-title)]">
+          {title}
+        </h3>
+        {myVote && (
+          <span className="shrink-0">
+            <MyVoteBadge shouldPass={myVote.shouldPass} />
+          </span>
+        )}
+      </div>
+      {!proposal.metadataResult.verified && (
+        <UnverifiedNote reason={proposal.metadataResult.reason} />
+      )}
+      <div className="mt-3">
+        <StatusLabel status={proposal.status} />
+      </div>
+      <dl className="mt-3 grid grid-cols-1 gap-2 text-sm sm:grid-cols-2">
+        <MobileField label="Proposer">
+          <span className="font-mono">
+            {truncateAddress(proposal.proposer)}
+          </span>
+        </MobileField>
+        <MobileField label="Voting Start">
+          {formatTimestamp(proposal.creationTimeSecs)}
+        </MobileField>
+        <MobileField label="Voting End">
+          {formatTimestamp(proposal.expirationSecs)}
+        </MobileField>
+        <MobileField label="Execution">
+          {formatTimestamp(proposal.resolutionTimeSecs)}
+        </MobileField>
+      </dl>
+    </Link>
+  );
+}
+
+function MobileField({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="min-w-0">
+      <dt className="text-xs uppercase tracking-wide text-[var(--color-text-secondary)]">
+        {label}
+      </dt>
+      <dd className="truncate">{children}</dd>
+    </div>
   );
 }

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -4,6 +4,7 @@ import githubIcon from "~/assets/svg/github.svg";
 import mediumIcon from "~/assets/svg/medium.svg";
 import twitterIcon from "~/assets/svg/twitter.svg";
 import {BrandMark} from "~/components/BrandMark";
+import {PAGE_SHELL_WIDTH_CLASS} from "~/lib/layout";
 
 const SOCIAL = [
   {
@@ -27,7 +28,9 @@ const SOCIAL = [
 export function SiteFooter() {
   return (
     <footer className="mt-16 bg-[var(--color-paper)]">
-      <div className="mx-auto flex max-w-7xl flex-col items-center gap-4 px-6 py-8 md:flex-row">
+      <div
+        className={`mx-auto flex ${PAGE_SHELL_WIDTH_CLASS} flex-col items-center gap-4 px-6 py-8 md:flex-row`}
+      >
         <a
           href="https://aptosfoundation.org/"
           target="_blank"

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -3,11 +3,14 @@ import logoIcon from "~/assets/svg/aptos_logo_icon.svg";
 import {BrandMark} from "~/components/BrandMark";
 import {ThemeToggle} from "~/components/ThemeToggle";
 import {WalletConnectButton} from "~/components/WalletConnectButton";
+import {PAGE_SHELL_WIDTH_CLASS} from "~/lib/layout";
 
 export function SiteHeader() {
   return (
     <header className="sticky top-0 z-20 border-b border-transparent bg-[var(--color-canvas)]/80 backdrop-blur-[10px]">
-      <div className="mx-auto flex h-20 max-w-7xl items-center gap-4 px-6">
+      <div
+        className={`mx-auto flex h-20 ${PAGE_SHELL_WIDTH_CLASS} items-center gap-4 px-6`}
+      >
         <Link
           to="/"
           search={{page: 0, status: "all"}}

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -1,0 +1,7 @@
+/**
+ * Horizontal cap for header / main / footer. The original governance
+ * layout used MUI `Container maxWidth="xl"` (1536px). `max-w-7xl`
+ * (1280px) is too narrow for the proposals table and causes a
+ * horizontal scrollbar.
+ */
+export const PAGE_SHELL_WIDTH_CLASS = "max-w-screen-2xl";

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -6,6 +6,7 @@ import {
 } from "@tanstack/react-router";
 import {SiteFooter} from "~/components/SiteFooter";
 import {SiteHeader} from "~/components/SiteHeader";
+import {PAGE_SHELL_WIDTH_CLASS} from "~/lib/layout";
 import {AppWalletProvider} from "~/lib/wallet/provider";
 import appCss from "~/styles/app.css?url";
 
@@ -53,7 +54,9 @@ function RootComponent() {
       <AppWalletProvider>
         <div id="app-shell">
           <SiteHeader />
-          <div className="mx-auto w-full max-w-7xl flex-1 px-6 pt-8">
+          <div
+            className={`mx-auto w-full ${PAGE_SHELL_WIDTH_CLASS} flex-1 px-6 pt-8`}
+          >
             <Outlet />
           </div>
           <SiteFooter />

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -155,6 +155,9 @@ h4 {
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--color-text-secondary);
+  white-space: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .gov-table tbody td {
@@ -162,6 +165,8 @@ h4 {
   background: var(--color-paper);
   border: 0;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .gov-table tbody td:first-child {
@@ -208,4 +213,5 @@ h4 {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  overflow-x: clip;
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -169,6 +169,10 @@ h4 {
   text-overflow: ellipsis;
 }
 
+.gov-table tbody td.gov-table-wrap {
+  white-space: normal;
+}
+
 .gov-table tbody td:first-child {
   border-radius: 8px 0 0 8px;
 }

--- a/tests/e2e/proposals-overflow.spec.ts
+++ b/tests/e2e/proposals-overflow.spec.ts
@@ -1,0 +1,51 @@
+import {expect, test} from "@playwright/test";
+
+async function horizontalOverflow(page: import("@playwright/test").Page) {
+  return page.evaluate(() => {
+    const root = document.documentElement;
+    return {
+      innerWidth: window.innerWidth,
+      documentScrollWidth: root.scrollWidth,
+      bodyScrollWidth: document.body.scrollWidth,
+    };
+  });
+}
+
+test("proposals list does not overflow on desktop and stacks on mobile", async ({
+  page,
+}) => {
+  await page.setViewportSize({width: 1440, height: 900});
+  await page.goto("/");
+  await expect(page.getByTestId("proposals-table")).toBeVisible();
+  await expect(page.getByTestId("proposals-mobile-list")).toBeHidden();
+
+  const desktop = await horizontalOverflow(page);
+  expect(desktop.documentScrollWidth).toBeLessThanOrEqual(
+    desktop.innerWidth + 1,
+  );
+
+  await page.getByTestId("proposals-table").screenshot({
+    path: "tests/e2e/artifacts/proposals-desktop.png",
+  });
+
+  await page.setViewportSize({width: 390, height: 844});
+  await expect(page.getByTestId("proposals-mobile-list")).toBeVisible();
+  await expect(page.getByTestId("proposals-table")).toBeHidden();
+  await expect(
+    page.getByTestId("proposals-mobile-list").getByRole("link").first(),
+  ).toBeVisible();
+
+  const mobile = await horizontalOverflow(page);
+  expect(mobile.documentScrollWidth).toBeLessThanOrEqual(mobile.innerWidth + 1);
+
+  await page.getByTestId("proposals-mobile-list").screenshot({
+    path: "tests/e2e/artifacts/proposals-mobile.png",
+  });
+
+  await page
+    .getByTestId("proposals-mobile-list")
+    .getByRole("link")
+    .first()
+    .click();
+  await expect(page).toHaveURL(/\/proposal\//);
+});

--- a/tests/unit/ProposalsTable.test.tsx
+++ b/tests/unit/ProposalsTable.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import {cleanup, render, screen} from "@testing-library/react";
+import {afterEach, beforeAll, describe, expect, it} from "vitest";
+import {ProposalsTable} from "~/components/ProposalsTable";
+import type {ProposalListItem} from "~/lib/governance/types";
+
+beforeAll(() => {
+  window.scrollTo = () => {
+    /* jsdom stub */
+  };
+});
+
+const longErrorReason =
+  "Failed to load metadata from https://raw.githubusercontent.com/aptos-foundation/mainnet-proposals/refs/heads/main/metadata/this-path-is-intentionally-very-long-so-it-would-blow-out-a-nowrap-table-row/metadata.json: hash mismatch deadbeef".repeat(
+    3,
+  );
+
+function makeProposal(
+  overrides: Partial<ProposalListItem> = {},
+): ProposalListItem {
+  return {
+    proposalId: "142",
+    proposer:
+      "0xdb009ab1a3259c4b27a0d8ff9d0e913e13e4c8b657fc73768f4e9bb811c7a1d8",
+    status: "active",
+    creationTimeSecs: 1_700_000_000n,
+    expirationSecs: 1_700_086_400n,
+    resolutionTimeSecs: null,
+    minVoteThreshold: 100n,
+    earlyResolutionVoteThreshold: null,
+    yesVotes: 80n,
+    noVotes: 10n,
+    executionHash: "0x00",
+    metadataLocation: "https://example.com/meta.json",
+    metadataHashHex: "0xdead",
+    metadataResult: {
+      verified: true,
+      metadata: {
+        title: "Aptos Improvement Proposal 142",
+        description: "desc",
+        source_code_url: "https://example.com/src",
+        discussion_url: "https://example.com/discuss",
+      },
+    },
+    ...overrides,
+  };
+}
+
+function renderWithRouter(ui: React.ReactElement) {
+  const rootRoute = createRootRoute();
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/",
+    component: () => ui,
+  });
+  const proposalRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/proposal/$proposalId",
+    component: () => null,
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, proposalRoute]),
+    history: createMemoryHistory({initialEntries: ["/"]}),
+  });
+  return render(<RouterProvider router={router} />);
+}
+
+describe("ProposalsTable", () => {
+  afterEach(cleanup);
+
+  it("keeps the desktop table behind an xl breakpoint so thin viewports use the stacked list", async () => {
+    renderWithRouter(<ProposalsTable proposals={[makeProposal()]} />);
+
+    const table = await screen.findByTestId("proposals-table");
+    expect(table.className).toMatch(/\bhidden\b/);
+    expect(table.className).toMatch(/\bxl:block\b/);
+
+    const mobile = screen.getByTestId("proposals-mobile-list");
+    expect(mobile.className).toMatch(/\bxl:hidden\b/);
+  });
+
+  it("renders the same proposals in the stacked mobile list", async () => {
+    renderWithRouter(
+      <ProposalsTable
+        proposals={[
+          makeProposal({proposalId: "142"}),
+          makeProposal({
+            proposalId: "138",
+            metadataResult: {verified: false, reason: "hash mismatch"},
+          }),
+        ]}
+      />,
+    );
+
+    const mobile = await screen.findByTestId("proposals-mobile-list");
+    expect(mobile).toHaveTextContent("Aptos Improvement Proposal 142");
+    expect(mobile).toHaveTextContent("Proposal #138");
+    expect(mobile.querySelectorAll("a")).toHaveLength(2);
+    expect(mobile.querySelector("a")?.getAttribute("href")).toBe(
+      "/proposal/142?votesPage=0",
+    );
+  });
+
+  it("does not dump a long unverified-metadata error into a nowrap table cell", async () => {
+    const errored = makeProposal({
+      proposalId: "138",
+      metadataResult: {verified: false, reason: longErrorReason},
+    });
+    renderWithRouter(<ProposalsTable proposals={[errored]} />);
+
+    expect(await screen.findByTestId("proposals-table")).toBeInTheDocument();
+    expect(screen.queryByText(longErrorReason)).not.toBeInTheDocument();
+    expect(screen.getAllByText("Proposal #138").length).toBeGreaterThan(0);
+
+    const errorNotes = screen.getAllByText(/metadata unverified/i);
+    expect(errorNotes.length).toBeGreaterThan(0);
+    for (const note of errorNotes) {
+      expect(note.className).toMatch(/truncate/);
+      expect(note).toHaveAttribute("title", longErrorReason);
+    }
+  });
+});

--- a/tests/unit/layout.test.ts
+++ b/tests/unit/layout.test.ts
@@ -1,0 +1,30 @@
+import {readFileSync} from "node:fs";
+import path from "node:path";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {PAGE_SHELL_WIDTH_CLASS} from "~/lib/layout";
+
+const rootDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+describe("page shell width", () => {
+  it("matches the original MUI xl container (1536px), not the narrower 7xl", () => {
+    expect(PAGE_SHELL_WIDTH_CLASS).toBe("max-w-screen-2xl");
+    expect(PAGE_SHELL_WIDTH_CLASS).not.toBe("max-w-7xl");
+  });
+
+  it("is used by the header, page body, and footer so columns stay aligned", () => {
+    const files = [
+      "src/routes/__root.tsx",
+      "src/components/SiteHeader.tsx",
+      "src/components/SiteFooter.tsx",
+    ];
+    for (const relative of files) {
+      const source = readFileSync(path.join(rootDir, relative), "utf8");
+      expect(source, relative).toContain("PAGE_SHELL_WIDTH_CLASS");
+      expect(source, relative).not.toContain("max-w-7xl");
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #38.

The proposals table was wider than the `max-w-7xl` (1280px) page shell. Combined with `white-space: nowrap` on every cell, a long row (such as an unverified / failed proposal like #138) forced a horizontal scrollbar.

This restores the original MUI `xl` width (1536px) for header, main, and footer, and switches to a stacked card list below the `xl` breakpoint so phones and narrow windows do not get a squeezed six-column table.

- Page shell: `max-w-7xl` → `max-w-screen-2xl`
- Desktop table uses `table-fixed` plus truncation so it cannot overflow its container
- Date cells wrap instead of ellipsizing, so full timestamps stay visible at 1280px
- Unverified metadata shows a truncated “Metadata unverified” note (full reason on hover) instead of dumping a long error string into a nowrap cell
- Below `xl` (1280px): stacked proposal cards with title, status, proposer, and dates
- Hero title scales down on small screens so “Governance” cannot overflow the viewport

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-494d96b3-3fc7-4ef0-ba41-ae9c93ec4135?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-494d96b3-3fc7-4ef0-ba41-ae9c93ec4135&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

