### PR TITLE
Split Geomi API keys into backend and frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,10 +16,18 @@
 # If you see "client API key" (AG-…) or "No API key found", the dashboard
 # value is the wrong type or the variable name does not match.
 #
-# A client key (starts with AG-) will still be sent, but Geomi applies
-# extra Origin checks and per-IP limits meant for browsers. Prefer a
-# server key for this deployment.
+# A client key (starts with AG-) needs an Origin header on SSR.
+# Without one, Geomi 401s ("Origin header is required") and the
+# proposals page crashes. This app attaches Origin only when
+# APTOS_API_ORIGIN is set; otherwise the client key is skipped and
+# the public endpoint is used instead.
+# Prefer a server key for this deployment.
 APTOS_BUILD_API_KEY=
+
+# Optional Origin for SSR when using a client key. Must match a URL
+# allowlisted on that key. Leave unset to skip the client key on the
+# server (recommended unless you have a server key).
+APTOS_API_ORIGIN=
 
 # Endpoint overrides. Both default to hosted mainnet when unset; the e2e suite
 # points them at a local mock server. Geomi keys authenticate against these

--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@
 #
 # Create a Geomi *server* key at https://geomi.dev (starts with
 # aptoslabs_). Set it on Vercel as APTOS_BUILD_API_KEY.
+# Do not use VITE_APTOS_BUILD_API_KEY — that name is ignored and would
+# inline the server secret into the public bundle.
 #
 # After deploy, serverless logs should show:
 #   [aptos] Using backend server API key from APTOS_BUILD_API_KEY

--- a/.env.example
+++ b/.env.example
@@ -1,33 +1,19 @@
-# Server-side only. These are read with process.env inside server functions and
-# are never exposed to the browser, so they must NOT use the VITE_ prefix.
-
-# Geomi / Aptos Labs API key for fullnode + indexer (strongly recommended
-# in production). Create one at https://geomi.dev — use a *server* key
-# (starts with aptoslabs_) because this app calls Aptos from Vercel SSR,
-# not from the browser.
+# Backend key — server-side only. Read with process.env inside server
+# functions and never inlined into the browser bundle.
 #
-# Right:  APTOS_BUILD_API_KEY=aptoslabs_...
-# Also accepted as fallbacks if you already set them in Vercel:
-#   GEOMI_API_KEY, VITE_APTOS_BUILD_API_KEY, VITE_GEOMI_API_KEY,
-#   VITE_APTOS_API_KEY_MAINNET, VITE_APTOS_API_KEY
+# Create a Geomi *server* key at https://geomi.dev (starts with
+# aptoslabs_). Set it on Vercel as APTOS_BUILD_API_KEY.
 #
-# After deploy, Vercel function logs should show:
-#   [aptos] Using server API key from APTOS_BUILD_API_KEY
-# If you see "client API key" (AG-…) or "No API key found", the dashboard
-# value is the wrong type or the variable name does not match.
-#
-# A client key (starts with AG-) needs an Origin header on SSR.
-# Without one, Geomi 401s ("Origin header is required") and the
-# proposals page crashes. This app attaches Origin only when
-# APTOS_API_ORIGIN is set; otherwise the client key is skipped and
-# the public endpoint is used instead.
-# Prefer a server key for this deployment.
+# After deploy, serverless logs should show:
+#   [aptos] Using backend server API key from APTOS_BUILD_API_KEY
 APTOS_BUILD_API_KEY=
 
-# Optional Origin for SSR when using a client key. Must match a URL
-# allowlisted on that key. Leave unset to skip the client key on the
-# server (recommended unless you have a server key).
-APTOS_API_ORIGIN=
+# Frontend key — inlined into the public client bundle (VITE_ prefix).
+# Create a Geomi *client* key (starts with AG-) with this site's origin
+# allowlisted. Used by the wallet adapter and browser Aptos SDK calls.
+#
+# Also accepted: VITE_APTOS_API_KEY_MAINNET, VITE_GEOMI_API_KEY
+VITE_APTOS_API_KEY=
 
 # Endpoint overrides. Both default to hosted mainnet when unset; the e2e suite
 # points them at a local mock server. Geomi keys authenticate against these

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,9 @@ If any fail, report exact failure and do not claim success.
 ## Environment
 
 - Use `.env.local` for local config.
-- Config is read server-side with `process.env`; do not use the `VITE_*` prefix,
-  which would inline the value into the public client bundle.
+- Backend secrets are read with `process.env` (no `VITE_*` prefix).
+- The frontend Geomi client key uses `VITE_APTOS_API_KEY` so Vite inlines it
+  into the browser bundle. Do not put a server key (`aptoslabs_…`) there.
 - Current supported vars are listed in `.env.example`.
 - Production hosting is Vercel; set the same vars in the Vercel project.
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ SSR: a browser client key (`AG-…`) sent from Node has no `Origin` header.
   inlined into the client bundle. Create one at https://geomi.dev. This is the
   key that avoids public-endpoint rate limits on Vercel SSR.
   Also accepted: `GEOMI_API_KEY`, `APTOS_API_KEY`.
+  `VITE_APTOS_BUILD_API_KEY` is **not** read — a `VITE_` name would inline the
+  server secret. Copy that value to `APTOS_BUILD_API_KEY` and delete the
+  `VITE_` variable.
 - `VITE_APTOS_API_KEY` (frontend): Geomi **client** key (`AG-…`), inlined into
   the browser bundle. Allowlist this site's origin on the key. Used by the
   wallet adapter and client-side Aptos SDK calls (`waitForTransaction`).

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ so secrets are not inlined into the client bundle.
   Labs **server** API key (`aptoslabs_…`) sent as `Authorization: Bearer` on
   fullnode and indexer requests. Create one at https://geomi.dev. This is the
   key that avoids public-endpoint rate limits on Vercel SSR.
+- `APTOS_API_ORIGIN` (optional): Origin header sent on SSR Aptos/Geomi
+  requests. Set this only when you intentionally use a client key (`AG-…`)
+  for SSR; it must match a URL allowlisted on that key. If unset, client
+  keys are not sent from the server (the public endpoint is used instead).
 - `APTOS_FULLNODE_URL` (optional): fullnode override; defaults to hosted mainnet
 - `APTOS_INDEXER_URL` (optional): indexer override; defaults to
   `https://api.mainnet.aptoslabs.com/v1/graphql`
@@ -56,8 +60,11 @@ so secrets are not inlined into the client bundle.
 Geomi keys authenticate against those Aptos Labs hosts. Do not point the
 endpoints at `api.geomi.dev`.
 
-A client key (`AG-…`) will still be sent, but Geomi applies Origin / per-IP
-limits meant for browsers. Prefer a server key for this deployment.
+A client key (`AG-…`) is for browsers. Geomi 401s SSR with
+`Unauthorized: Origin header is required` if it is sent without an Origin.
+This app attaches Origin on the server only when `APTOS_API_ORIGIN` is set
+and otherwise skips the client key so the public endpoint is used instead of
+crashing the proposals page. Prefer a server key for this deployment.
 
 If you already set a key on Vercel under a legacy name, it is still read, in
 this order: `APTOS_BUILD_API_KEY`, `GEOMI_API_KEY`, `VITE_APTOS_BUILD_API_KEY`,
@@ -70,10 +77,11 @@ function logs. You should see one of:
 
 - `[aptos] Using server API key from APTOS_BUILD_API_KEY` — correct.
   Server keys start with `aptoslabs_`.
-- `[aptos] Using client API key from VITE_…` — the value is a browser
-  (`AG-…`) key. It will still be sent, but Geomi applies Origin / per-IP
-  limits meant for wallets, so SSR on Vercel can still 429. Create a
-  **server** key at https://geomi.dev and store it as `APTOS_BUILD_API_KEY`.
+- `[aptos] Using client API key from … with Origin https://…` — a browser
+  (`AG-…`) key is being used for SSR. It works only if that Origin is on the
+  Geomi allowlist. Prefer a **server** key as `APTOS_BUILD_API_KEY`.
+- `[aptos] Ignoring client API key … during SSR` — a client key was found but
+  no Origin could be attached, so the public endpoint is used.
 - `[aptos] No API key found` — the dashboard name does not match any of
   the names above (or the variable is empty). Add `APTOS_BUILD_API_KEY`.
 

--- a/README.md
+++ b/README.md
@@ -41,52 +41,33 @@ Open `http://localhost:3000`.
 
 ## Environment Variables
 
-This app renders on the server, so its configuration is read with `process.env`
-inside server functions and never reaches the browser. Prefer unprefixed names
-so secrets are not inlined into the client bundle.
+This app uses **two** Geomi / Aptos Labs API keys. Mixing them is what 401s
+SSR: a browser client key (`AG-…`) sent from Node has no `Origin` header.
 
-- `APTOS_BUILD_API_KEY` (optional, recommended in production): Geomi / Aptos
-  Labs **server** API key (`aptoslabs_…`) sent as `Authorization: Bearer` on
-  fullnode and indexer requests. Create one at https://geomi.dev. This is the
+- `APTOS_BUILD_API_KEY` (backend, recommended in production): Geomi **server**
+  key (`aptoslabs_…`). Read with `process.env` in server functions and never
+  inlined into the client bundle. Create one at https://geomi.dev. This is the
   key that avoids public-endpoint rate limits on Vercel SSR.
-- `APTOS_API_ORIGIN` (optional): Origin header sent on SSR Aptos/Geomi
-  requests. Set this only when you intentionally use a client key (`AG-…`)
-  for SSR; it must match a URL allowlisted on that key. If unset, client
-  keys are not sent from the server (the public endpoint is used instead).
+  Also accepted: `GEOMI_API_KEY`, `APTOS_API_KEY`.
+- `VITE_APTOS_API_KEY` (frontend): Geomi **client** key (`AG-…`), inlined into
+  the browser bundle. Allowlist this site's origin on the key. Used by the
+  wallet adapter and client-side Aptos SDK calls (`waitForTransaction`).
+  Also accepted: `VITE_APTOS_API_KEY_MAINNET`, `VITE_GEOMI_API_KEY`.
 - `APTOS_FULLNODE_URL` (optional): fullnode override; defaults to hosted mainnet
 - `APTOS_INDEXER_URL` (optional): indexer override; defaults to
   `https://api.mainnet.aptoslabs.com/v1/graphql`
 
-Geomi keys authenticate against those Aptos Labs hosts. Do not point the
-endpoints at `api.geomi.dev`.
-
-A client key (`AG-…`) is for browsers. Geomi 401s SSR with
-`Unauthorized: Origin header is required` if it is sent without an Origin.
-This app attaches Origin on the server only when `APTOS_API_ORIGIN` is set
-and otherwise skips the client key so the public endpoint is used instead of
-crashing the proposals page. Prefer a server key for this deployment.
-
-If you already set a key on Vercel under a legacy name, it is still read, in
-this order: `APTOS_BUILD_API_KEY`, `GEOMI_API_KEY`, `VITE_APTOS_BUILD_API_KEY`,
-`VITE_GEOMI_API_KEY`, `VITE_APTOS_API_KEY_MAINNET`, `VITE_APTOS_API_KEY`,
-`APTOS_API_KEY`. `VITE_*` names are also read from `import.meta.env` so a key
-that was only present at build time still works.
+Geomi keys authenticate against those Aptos Labs hosts. Do not point
+`APTOS_FULLNODE_URL` / `APTOS_INDEXER_URL` at `api.geomi.dev`.
 
 **Is the Vercel key the right type?** After a deploy, open the serverless
 function logs. You should see one of:
 
-- `[aptos] Using server API key from APTOS_BUILD_API_KEY` — correct.
-  Server keys start with `aptoslabs_`.
-- `[aptos] Using client API key from … with Origin https://…` — a browser
-  (`AG-…`) key is being used for SSR. It works only if that Origin is on the
-  Geomi allowlist. Prefer a **server** key as `APTOS_BUILD_API_KEY`.
-- `[aptos] Ignoring client API key … during SSR` — a client key was found but
-  no Origin could be attached, so the public endpoint is used.
-- `[aptos] No API key found` — the dashboard name does not match any of
-  the names above (or the variable is empty). Add `APTOS_BUILD_API_KEY`.
-
-Do not point `APTOS_FULLNODE_URL` / `APTOS_INDEXER_URL` at `api.geomi.dev`.
-Geomi keys authenticate against the hosted Aptos Labs URLs.
+- `[aptos] Using backend server API key from APTOS_BUILD_API_KEY` — correct.
+- `[aptos] No backend API key found` — add `APTOS_BUILD_API_KEY` (server key).
+- `[aptos] Ignoring client API key from APTOS_BUILD_API_KEY` — that value is an
+  `AG-…` key. Put the client key in `VITE_APTOS_API_KEY` and a server key in
+  `APTOS_BUILD_API_KEY`.
 
 List and proposal HTML is cached at the Vercel edge for 15 seconds
 (`s-maxage=15`, `stale-while-revalidate=45`), matching the in-process TTL

--- a/src/components/ApiErrorAlert.tsx
+++ b/src/components/ApiErrorAlert.tsx
@@ -1,0 +1,45 @@
+import {
+  isRateLimitError,
+  RATE_LIMIT_MESSAGE,
+} from "~/lib/governance/rate-limit";
+
+export function errorAlertCopy(error: unknown): {title: string; body: string} {
+  if (isRateLimitError(error)) {
+    return {title: "Rate Limited", body: RATE_LIMIT_MESSAGE};
+  }
+  const body =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : String(error);
+  return {title: "Error", body};
+}
+
+export function ApiErrorAlert({
+  error,
+  onRetry,
+}: {
+  error: unknown;
+  onRetry?: () => void;
+}) {
+  const {title, body} = errorAlertCopy(error);
+  return (
+    <div
+      role="alert"
+      className="mb-4 rounded border border-[var(--color-error)] p-4 text-[var(--color-error)]"
+    >
+      <p className="font-semibold">{title}</p>
+      <p className="mt-1 break-words">{body}</p>
+      {onRetry ? (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-3 rounded border border-[var(--color-error)] px-3 py-1 text-sm"
+        >
+          Try again
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/RouteError.tsx
+++ b/src/components/RouteError.tsx
@@ -1,0 +1,6 @@
+import type {ErrorComponentProps} from "@tanstack/react-router";
+import {ApiErrorAlert} from "~/components/ApiErrorAlert";
+
+export function RouteError({error, reset}: ErrorComponentProps) {
+  return <ApiErrorAlert error={error} onRetry={reset} />;
+}

--- a/src/lib/aptos/client.ts
+++ b/src/lib/aptos/client.ts
@@ -13,12 +13,11 @@ let cachedClient: Aptos | null = null;
  * Safe to call from server functions and from client code — this
  * only wraps read/view/submit RPC calls, never private keys.
  *
- * API keys: Geomi (formerly Aptos Build / Aptos Labs Developer Portal)
- * keys are sent as `Authorization: Bearer`. A server key (`aptoslabs_…`)
- * is the right type for this SSR app. Legacy Vercel names such as
- * `VITE_APTOS_API_KEY_MAINNET` are still accepted so an existing
- * dashboard secret keeps working. Keys authenticate against Aptos Labs
- * hosted URLs — do not point fullnode/indexer at api.geomi.dev.
+ * API keys are split by runtime:
+ * - Server: `APTOS_BUILD_API_KEY` (Geomi server key, `aptoslabs_…`)
+ * - Browser: `VITE_APTOS_API_KEY` (Geomi client key, `AG-…`)
+ * Keys authenticate against Aptos Labs hosted URLs — do not point
+ * fullnode/indexer at api.geomi.dev.
  */
 export function getAptosClient(): Aptos {
   if (!cachedClient) {
@@ -28,12 +27,7 @@ export function getAptosClient(): Aptos {
       new AptosConfig({
         network: Network.MAINNET,
         fullnode: config.fullnodeUrl,
-        clientConfig: {
-          ...(config.apiKey ? {API_KEY: config.apiKey} : {}),
-          ...(config.requestOrigin
-            ? {HEADERS: {Origin: config.requestOrigin}}
-            : {}),
-        },
+        clientConfig: config.apiKey ? {API_KEY: config.apiKey} : undefined,
       }),
     );
   }

--- a/src/lib/aptos/client.ts
+++ b/src/lib/aptos/client.ts
@@ -28,7 +28,12 @@ export function getAptosClient(): Aptos {
       new AptosConfig({
         network: Network.MAINNET,
         fullnode: config.fullnodeUrl,
-        clientConfig: config.apiKey ? {API_KEY: config.apiKey} : undefined,
+        clientConfig: {
+          ...(config.apiKey ? {API_KEY: config.apiKey} : {}),
+          ...(config.requestOrigin
+            ? {HEADERS: {Origin: config.requestOrigin}}
+            : {}),
+        },
       }),
     );
   }

--- a/src/lib/governance/api-config.ts
+++ b/src/lib/governance/api-config.ts
@@ -67,13 +67,18 @@ function isBrowser(): boolean {
 
 export function resolveApiKey(): ResolvedApiKey {
   const names = isBrowser() ? CLIENT_KEY_ENV_NAMES : SERVER_KEY_ENV_NAMES;
+  const expectedKind: ApiKeyKind = isBrowser() ? "client" : "server";
+  let firstWrongKind: ResolvedApiKey | undefined;
   for (const source of names) {
     const key = readEnv(source);
-    if (key) {
-      return {key, source, kind: classifyApiKey(key)};
+    if (!key) continue;
+    const kind = classifyApiKey(key);
+    if (kind === expectedKind) {
+      return {key, source, kind};
     }
+    firstWrongKind ??= {key, source, kind};
   }
-  return {kind: "none"};
+  return firstWrongKind ?? {kind: "none"};
 }
 
 /**

--- a/src/lib/governance/api-config.ts
+++ b/src/lib/governance/api-config.ts
@@ -8,6 +8,10 @@ export interface ResolvedApiKey {
 
 export interface ResolvedApiConfig extends ResolvedApiKey {
   apiKey?: string;
+  /** Origin to send on server-side Aptos/Geomi requests. Required for
+   *  client keys (`AG-…`); omitted in the browser where the runtime
+   *  sets Origin itself. */
+  requestOrigin?: string;
   fullnodeUrl?: string;
   indexerUrl: string;
 }
@@ -70,6 +74,57 @@ export function resolveApiKey(): ResolvedApiKey {
   return {kind: "none"};
 }
 
+/**
+ * Origin Geomi should see on SSR requests. Client keys (`AG-…`) 401
+ * with "Unauthorized: Origin header is required" when this is missing.
+ * Only an explicit APTOS_API_ORIGIN is used — it must be on the key's
+ * allowlist. Vercel hostnames are not guessed, because they often are
+ * not allowlisted and would still 401.
+ */
+export function resolveRequestOrigin(): string | undefined {
+  if (typeof window !== "undefined") return undefined;
+
+  const explicit = readEnv("APTOS_API_ORIGIN");
+  if (explicit) return stripTrailingSlash(explicit);
+
+  return undefined;
+}
+
+function stripTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+/**
+ * Key to put on outgoing Aptos/Geomi requests. Client keys (`AG-…`)
+ * require a browser `Origin` header; Node SSR does not send one, and
+ * Geomi then 401s with "Unauthorized: Origin header is required",
+ * which takes down the proposals page.
+ *
+ * On the server, send a client key only when we can attach an Origin.
+ * Otherwise skip it and use the public endpoint. The browser still
+ * sends client keys so wallet follow-up calls keep the origin check.
+ */
+export function outgoingApiKey(resolved: ResolvedApiKey): string | undefined {
+  if (!resolved.key) return undefined;
+  if (resolved.kind === "client" && typeof window === "undefined") {
+    return resolveRequestOrigin() ? resolved.key : undefined;
+  }
+  return resolved.key;
+}
+
+export function aptosRequestHeaders(
+  config: ResolvedApiConfig,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (config.apiKey) {
+    headers.Authorization = `Bearer ${config.apiKey}`;
+  }
+  if (config.requestOrigin) {
+    headers.Origin = config.requestOrigin;
+  }
+  return headers;
+}
+
 let loggedApiKey = false;
 
 export function logResolvedApiKey(resolved: ResolvedApiKey): void {
@@ -78,6 +133,21 @@ export function logResolvedApiKey(resolved: ResolvedApiKey): void {
   if (resolved.kind === "none") {
     console.warn(
       "[aptos] No API key found. Set APTOS_BUILD_API_KEY to a Geomi/Aptos Labs server key (aptoslabs_…) on Vercel to avoid public-endpoint rate limits. Legacy names such as VITE_APTOS_API_KEY_MAINNET are also accepted.",
+    );
+    return;
+  }
+  if (resolved.kind === "client" && typeof window === "undefined") {
+    if (outgoingApiKey(resolved)) {
+      console.info(
+        `[aptos] Using client API key from ${resolved.source} with Origin ${resolveRequestOrigin()}`,
+      );
+      console.warn(
+        "[aptos] Prefer a server key (aptoslabs_…) as APTOS_BUILD_API_KEY. Client keys work on SSR only when Origin matches the Geomi allowlist.",
+      );
+      return;
+    }
+    console.warn(
+      `[aptos] Ignoring client API key from ${resolved.source} during SSR. Geomi client keys (AG-…) require an Origin header and 401 without one, which takes down the proposals page. Using the public endpoint instead. Set APTOS_BUILD_API_KEY to a server key (aptoslabs_…) to avoid rate limits, or set APTOS_API_ORIGIN to an allowlisted origin.`,
     );
     return;
   }
@@ -95,7 +165,8 @@ export function resolveApiConfig(): ResolvedApiConfig {
   const resolved = resolveApiKey();
   return {
     ...resolved,
-    apiKey: resolved.key,
+    apiKey: outgoingApiKey(resolved),
+    requestOrigin: resolveRequestOrigin(),
     fullnodeUrl:
       readEnv("APTOS_FULLNODE_URL") || readEnv("VITE_GEOMI_FULLNODE_URL"),
     indexerUrl:

--- a/src/lib/governance/api-config.ts
+++ b/src/lib/governance/api-config.ts
@@ -8,41 +8,38 @@ export interface ResolvedApiKey {
 
 export interface ResolvedApiConfig extends ResolvedApiKey {
   apiKey?: string;
-  /** Origin to send on server-side Aptos/Geomi requests. Required for
-   *  client keys (`AG-…`); omitted in the browser where the runtime
-   *  sets Origin itself. */
-  requestOrigin?: string;
   fullnodeUrl?: string;
   indexerUrl: string;
 }
 
 const DEFAULT_INDEXER_URL = "https://api.mainnet.aptoslabs.com/v1/graphql";
 
-/** Env names accepted for a Geomi / Aptos Labs API key. First match wins.
- *  Vercel historically used the Vite-prefixed names from the CRA app;
- *  this server-rendered app prefers APTOS_BUILD_API_KEY so the secret
- *  is not inlined into the client bundle. */
-const API_KEY_ENV_NAMES = [
+/** Unprefixed names — available to Vercel serverless at runtime, never
+ *  inlined into the browser bundle. Use a Geomi *server* key
+ *  (`aptoslabs_…`) here. */
+const SERVER_KEY_ENV_NAMES = [
   "APTOS_BUILD_API_KEY",
   "GEOMI_API_KEY",
-  "VITE_APTOS_BUILD_API_KEY",
-  "VITE_GEOMI_API_KEY",
-  "VITE_APTOS_API_KEY_MAINNET",
-  "VITE_APTOS_API_KEY",
   "APTOS_API_KEY",
+] as const;
+
+/** Vite-prefixed names — inlined into the public client bundle. Use a
+ *  Geomi *client* key (`AG-…`) here so the browser Origin check works. */
+const CLIENT_KEY_ENV_NAMES = [
+  "VITE_APTOS_API_KEY",
+  "VITE_APTOS_API_KEY_MAINNET",
+  "VITE_GEOMI_API_KEY",
 ] as const;
 
 /**
  * Vite only inlines `import.meta.env.VITE_*` for *static* property
  * access. Dynamic `import.meta.env[name]` is undefined in the built
- * server bundle, which is why a Vercel `VITE_APTOS_API_KEY_MAINNET`
- * set at build time would be ignored without this map.
+ * bundle.
  */
 const VITE_ENV: Record<string, string | undefined> = {
-  VITE_APTOS_BUILD_API_KEY: import.meta.env.VITE_APTOS_BUILD_API_KEY,
-  VITE_GEOMI_API_KEY: import.meta.env.VITE_GEOMI_API_KEY,
-  VITE_APTOS_API_KEY_MAINNET: import.meta.env.VITE_APTOS_API_KEY_MAINNET,
   VITE_APTOS_API_KEY: import.meta.env.VITE_APTOS_API_KEY,
+  VITE_APTOS_API_KEY_MAINNET: import.meta.env.VITE_APTOS_API_KEY_MAINNET,
+  VITE_GEOMI_API_KEY: import.meta.env.VITE_GEOMI_API_KEY,
   VITE_GEOMI_FULLNODE_URL: import.meta.env.VITE_GEOMI_FULLNODE_URL,
   VITE_GEOMI_INDEXER_URL: import.meta.env.VITE_GEOMI_INDEXER_URL,
 };
@@ -64,8 +61,13 @@ export function classifyApiKey(key: string | undefined): ApiKeyKind {
   return "unknown";
 }
 
+function isBrowser(): boolean {
+  return typeof window !== "undefined";
+}
+
 export function resolveApiKey(): ResolvedApiKey {
-  for (const source of API_KEY_ENV_NAMES) {
+  const names = isBrowser() ? CLIENT_KEY_ENV_NAMES : SERVER_KEY_ENV_NAMES;
+  for (const source of names) {
     const key = readEnv(source);
     if (key) {
       return {key, source, kind: classifyApiKey(key)};
@@ -75,41 +77,17 @@ export function resolveApiKey(): ResolvedApiKey {
 }
 
 /**
- * Origin Geomi should see on SSR requests. Client keys (`AG-…`) 401
- * with "Unauthorized: Origin header is required" when this is missing.
- * Only an explicit APTOS_API_ORIGIN is used — it must be on the key's
- * allowlist. Vercel hostnames are not guessed, because they often are
- * not allowlisted and would still 401.
- */
-export function resolveRequestOrigin(): string | undefined {
-  if (typeof window !== "undefined") return undefined;
-
-  const explicit = readEnv("APTOS_API_ORIGIN");
-  if (explicit) return stripTrailingSlash(explicit);
-
-  return undefined;
-}
-
-function stripTrailingSlash(value: string): string {
-  return value.endsWith("/") ? value.slice(0, -1) : value;
-}
-
-/**
- * Key to put on outgoing Aptos/Geomi requests. Client keys (`AG-…`)
- * require a browser `Origin` header; Node SSR does not send one, and
- * Geomi then 401s with "Unauthorized: Origin header is required",
- * which takes down the proposals page.
- *
- * On the server, send a client key only when we can attach an Origin.
- * Otherwise skip it and use the public endpoint. The browser still
- * sends client keys so wallet follow-up calls keep the origin check.
+ * Key attached to outgoing Aptos/Geomi requests. Backend keys stay on
+ * the server; frontend keys stay in the browser. Mixing them is what
+ * 401'd SSR (`Origin header is required` for `AG-…` keys) and would
+ * leak an `aptoslabs_…` secret if inlined.
  */
 export function outgoingApiKey(resolved: ResolvedApiKey): string | undefined {
   if (!resolved.key) return undefined;
-  if (resolved.kind === "client" && typeof window === "undefined") {
-    return resolveRequestOrigin() ? resolved.key : undefined;
+  if (isBrowser()) {
+    return resolved.kind === "client" ? resolved.key : undefined;
   }
-  return resolved.key;
+  return resolved.kind === "server" ? resolved.key : undefined;
 }
 
 export function aptosRequestHeaders(
@@ -119,9 +97,6 @@ export function aptosRequestHeaders(
   if (config.apiKey) {
     headers.Authorization = `Bearer ${config.apiKey}`;
   }
-  if (config.requestOrigin) {
-    headers.Origin = config.requestOrigin;
-  }
   return headers;
 }
 
@@ -130,35 +105,25 @@ let loggedApiKey = false;
 export function logResolvedApiKey(resolved: ResolvedApiKey): void {
   if (loggedApiKey || process.env.VITEST) return;
   loggedApiKey = true;
+  const side = isBrowser() ? "frontend" : "backend";
   if (resolved.kind === "none") {
     console.warn(
-      "[aptos] No API key found. Set APTOS_BUILD_API_KEY to a Geomi/Aptos Labs server key (aptoslabs_…) on Vercel to avoid public-endpoint rate limits. Legacy names such as VITE_APTOS_API_KEY_MAINNET are also accepted.",
+      isBrowser()
+        ? "[aptos] No frontend API key found. Set VITE_APTOS_API_KEY to a Geomi client key (AG-…) for browser Aptos calls."
+        : "[aptos] No backend API key found. Set APTOS_BUILD_API_KEY to a Geomi server key (aptoslabs_…) on Vercel to avoid public-endpoint rate limits.",
     );
     return;
   }
-  if (resolved.kind === "client" && typeof window === "undefined") {
-    if (outgoingApiKey(resolved)) {
-      console.info(
-        `[aptos] Using client API key from ${resolved.source} with Origin ${resolveRequestOrigin()}`,
-      );
-      console.warn(
-        "[aptos] Prefer a server key (aptoslabs_…) as APTOS_BUILD_API_KEY. Client keys work on SSR only when Origin matches the Geomi allowlist.",
-      );
-      return;
-    }
+  const outgoing = outgoingApiKey(resolved);
+  if (!outgoing) {
     console.warn(
-      `[aptos] Ignoring client API key from ${resolved.source} during SSR. Geomi client keys (AG-…) require an Origin header and 401 without one, which takes down the proposals page. Using the public endpoint instead. Set APTOS_BUILD_API_KEY to a server key (aptoslabs_…) to avoid rate limits, or set APTOS_API_ORIGIN to an allowlisted origin.`,
+      `[aptos] Ignoring ${resolved.kind} API key from ${resolved.source} on the ${side}. Use aptoslabs_… as APTOS_BUILD_API_KEY (server) and AG-… as VITE_APTOS_API_KEY (browser).`,
     );
     return;
   }
   console.info(
-    `[aptos] Using ${resolved.kind} API key from ${resolved.source}`,
+    `[aptos] Using ${side} ${resolved.kind} API key from ${resolved.source}`,
   );
-  if (resolved.kind === "client") {
-    console.warn(
-      "[aptos] This looks like a Geomi/Aptos client key (AG-…). Prefer a server key (aptoslabs_…) for Vercel SSR — client keys apply Origin and per-IP limits meant for browsers.",
-    );
-  }
 }
 
 export function resolveApiConfig(): ResolvedApiConfig {
@@ -166,7 +131,6 @@ export function resolveApiConfig(): ResolvedApiConfig {
   return {
     ...resolved,
     apiKey: outgoingApiKey(resolved),
-    requestOrigin: resolveRequestOrigin(),
     fullnodeUrl:
       readEnv("APTOS_FULLNODE_URL") || readEnv("VITE_GEOMI_FULLNODE_URL"),
     indexerUrl:

--- a/src/lib/governance/indexer-client.ts
+++ b/src/lib/governance/indexer-client.ts
@@ -1,4 +1,8 @@
-import {logResolvedApiKey, resolveApiConfig} from "~/lib/governance/api-config";
+import {
+  aptosRequestHeaders,
+  logResolvedApiKey,
+  resolveApiConfig,
+} from "~/lib/governance/api-config";
 
 interface GraphQLResponse<T> {
   data?: T;
@@ -20,10 +24,8 @@ export async function executeIndexerQuery<T>(
   logResolvedApiKey(config);
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
+    ...aptosRequestHeaders(config),
   };
-  if (config.apiKey) {
-    headers.Authorization = `Bearer ${config.apiKey}`;
-  }
 
   const response = await fetch(config.indexerUrl, {
     method: "POST",

--- a/src/lib/wallet/provider.tsx
+++ b/src/lib/wallet/provider.tsx
@@ -4,6 +4,7 @@ import {Network} from "@aptos-labs/ts-sdk";
 import {AptosWalletAdapterProvider} from "@aptos-labs/wallet-adapter-react";
 import {ClientOnly} from "@tanstack/react-router";
 import type {ReactNode} from "react";
+import {resolveApiConfig} from "~/lib/governance/api-config";
 
 /**
  * AIP-62 wallet discovery runs entirely client-side (window event
@@ -16,18 +17,30 @@ import type {ReactNode} from "react";
 export function AppWalletProvider({children}: {children: ReactNode}) {
   return (
     <ClientOnly fallback={<>{children}</>}>
-      <AptosWalletAdapterProvider
-        autoConnect
-        dappConfig={{network: Network.MAINNET}}
-        onError={(error) => {
-          // Non-fatal: connection/signing errors surface inline in the
-          // components that triggered them (WalletConnectButton,
-          // VotingPanel) — this is a last-resort console log only.
-          console.error("[wallet-adapter]", error);
-        }}
-      >
-        {children}
-      </AptosWalletAdapterProvider>
+      <WalletAdapterWithFrontendKey>{children}</WalletAdapterWithFrontendKey>
     </ClientOnly>
+  );
+}
+
+function WalletAdapterWithFrontendKey({children}: {children: ReactNode}) {
+  const frontendKey = resolveApiConfig().apiKey;
+  return (
+    <AptosWalletAdapterProvider
+      autoConnect
+      dappConfig={{
+        network: Network.MAINNET,
+        aptosApiKeys: frontendKey
+          ? {[Network.MAINNET]: frontendKey}
+          : undefined,
+      }}
+      onError={(error) => {
+        // Non-fatal: connection/signing errors surface inline in the
+        // components that triggered them (WalletConnectButton,
+        // VotingPanel) — this is a last-resort console log only.
+        console.error("[wallet-adapter]", error);
+      }}
+    >
+      {children}
+    </AptosWalletAdapterProvider>
   );
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,6 +1,7 @@
 import {QueryClient} from "@tanstack/react-query";
 import {createRouter} from "@tanstack/react-router";
 import {setupRouterSsrQueryIntegration} from "@tanstack/react-router-ssr-query";
+import {RouteError} from "~/components/RouteError";
 import {routeTree} from "./routeTree.gen";
 
 /**
@@ -29,6 +30,7 @@ export function getRouter() {
     context: {queryClient},
     defaultPreload: "intent",
     scrollRestoration: true,
+    defaultErrorComponent: RouteError,
   });
 
   setupRouterSsrQueryIntegration({router, queryClient});

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,15 +2,12 @@ import {useWallet} from "@aptos-labs/wallet-adapter-react";
 import {useQuery} from "@tanstack/react-query";
 import {createFileRoute, useNavigate} from "@tanstack/react-router";
 import {z} from "zod";
+import {ApiErrorAlert} from "~/components/ApiErrorAlert";
 import {PageHeader} from "~/components/PageHeader";
 import {PaginationBar} from "~/components/PaginationBar";
 import {ProposalsTable} from "~/components/ProposalsTable";
 import {fetchMyVotes} from "~/lib/governance/fetch-my-votes";
 import {listProposals} from "~/lib/governance/fetch-proposals";
-import {
-  isRateLimitError,
-  RATE_LIMIT_MESSAGE,
-} from "~/lib/governance/rate-limit";
 import type {ProposalStatus} from "~/lib/governance/types";
 
 const STATUS_FILTERS = [
@@ -138,19 +135,7 @@ function Home() {
           ))}
         </div>
 
-        {isError && (
-          <div
-            role="alert"
-            className="mb-4 rounded border border-[var(--color-error)] p-4 text-[var(--color-error)]"
-          >
-            <p className="font-semibold">
-              {isRateLimitError(error) ? "Rate Limited" : "Error"}
-            </p>
-            <p className="mt-1">
-              {isRateLimitError(error) ? RATE_LIMIT_MESSAGE : String(error)}
-            </p>
-          </div>
-        )}
+        {isError && <ApiErrorAlert error={error} />}
 
         {filteredItems.length === 0 ? (
           <p className="mt-6 text-[var(--color-text-secondary)]">

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,10 +2,9 @@
 /// <reference types="vitest/globals" />
 
 interface ImportMetaEnv {
-  readonly VITE_APTOS_BUILD_API_KEY?: string;
-  readonly VITE_GEOMI_API_KEY?: string;
-  readonly VITE_APTOS_API_KEY_MAINNET?: string;
   readonly VITE_APTOS_API_KEY?: string;
+  readonly VITE_APTOS_API_KEY_MAINNET?: string;
+  readonly VITE_GEOMI_API_KEY?: string;
   readonly VITE_GEOMI_FULLNODE_URL?: string;
   readonly VITE_GEOMI_INDEXER_URL?: string;
 }

--- a/tests/unit/ApiErrorAlert.test.tsx
+++ b/tests/unit/ApiErrorAlert.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import {cleanup, render, screen} from "@testing-library/react";
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {ApiErrorAlert} from "~/components/ApiErrorAlert";
+import {RATE_LIMIT_MESSAGE} from "~/lib/governance/rate-limit";
+
+describe("ApiErrorAlert", () => {
+  afterEach(cleanup);
+
+  it("shows the Aptos Origin 401 instead of a generic crash message", () => {
+    render(
+      <ApiErrorAlert
+        error={
+          new Error(
+            'Account resource/0x1::voting::VotingForum<0x1::governance_proposal::GovernanceProposal> failed with status: Unauthorized(code:401) and response body: "Unauthorized: Origin header is required"',
+          )
+        }
+      />,
+    );
+    expect(screen.queryByText(/something went wrong/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /Origin header is required/i,
+    );
+  });
+
+  it("uses the rate-limit copy for 429s", () => {
+    render(<ApiErrorAlert error={new Error("429 Too Many Requests")} />);
+    expect(screen.getByText("Rate Limited")).toBeInTheDocument();
+    expect(screen.getByText(RATE_LIMIT_MESSAGE)).toBeInTheDocument();
+  });
+
+  it("retries when Try again is clicked", () => {
+    const onRetry = vi.fn();
+    render(<ApiErrorAlert error={new Error("boom")} onRetry={onRetry} />);
+    screen.getByRole("button", {name: /try again/i}).click();
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/api-config.browser.test.ts
+++ b/tests/unit/api-config.browser.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import {afterEach, describe, expect, it} from "vitest";
+import {resolveApiConfig, resolveApiKey} from "~/lib/governance/api-config";
+
+const KEY_ENVS = [
+  "APTOS_BUILD_API_KEY",
+  "GEOMI_API_KEY",
+  "VITE_GEOMI_API_KEY",
+  "VITE_APTOS_API_KEY_MAINNET",
+  "VITE_APTOS_API_KEY",
+  "APTOS_API_KEY",
+] as const;
+
+const originalEnv: Record<string, string | undefined> = {};
+
+function clearKeyEnvs() {
+  for (const name of KEY_ENVS) {
+    if (!(name in originalEnv)) originalEnv[name] = process.env[name];
+    delete process.env[name];
+  }
+}
+
+afterEach(() => {
+  for (const name of KEY_ENVS) {
+    const value = originalEnv[name];
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+});
+
+describe("resolveApiKey in the browser", () => {
+  it("uses the frontend key and ignores the backend key", () => {
+    clearKeyEnvs();
+    process.env.APTOS_BUILD_API_KEY = "aptoslabs_server_key";
+    process.env.VITE_APTOS_API_KEY = "AG-CLIENTKEY";
+    const resolved = resolveApiKey();
+    expect(resolved.source).toBe("VITE_APTOS_API_KEY");
+    expect(resolved.key).toBe("AG-CLIENTKEY");
+    expect(resolved.kind).toBe("client");
+    expect(resolveApiConfig().apiKey).toBe("AG-CLIENTKEY");
+  });
+
+  it("accepts the legacy Vite mainnet client key name", () => {
+    clearKeyEnvs();
+    process.env.VITE_APTOS_API_KEY_MAINNET = "AG-LEGACYCLIENT";
+    expect(resolveApiKey().source).toBe("VITE_APTOS_API_KEY_MAINNET");
+    expect(resolveApiConfig().apiKey).toBe("AG-LEGACYCLIENT");
+  });
+
+  it("does not send a backend server key from the browser", () => {
+    clearKeyEnvs();
+    process.env.VITE_APTOS_API_KEY = "aptoslabs_leaked_server_key";
+    const config = resolveApiConfig();
+    expect(config.kind).toBe("server");
+    expect(config.apiKey).toBeUndefined();
+  });
+});

--- a/tests/unit/api-config.browser.test.ts
+++ b/tests/unit/api-config.browser.test.ts
@@ -54,4 +54,14 @@ describe("resolveApiKey in the browser", () => {
     expect(config.kind).toBe("server");
     expect(config.apiKey).toBeUndefined();
   });
+
+  it("skips a server key in VITE_APTOS_API_KEY and uses a later client key", () => {
+    clearKeyEnvs();
+    process.env.VITE_APTOS_API_KEY = "aptoslabs_leaked_server_key";
+    process.env.VITE_APTOS_API_KEY_MAINNET = "AG-LEGACYCLIENT";
+    const resolved = resolveApiKey();
+    expect(resolved.source).toBe("VITE_APTOS_API_KEY_MAINNET");
+    expect(resolved.kind).toBe("client");
+    expect(resolveApiConfig().apiKey).toBe("AG-LEGACYCLIENT");
+  });
 });

--- a/tests/unit/api-config.test.ts
+++ b/tests/unit/api-config.test.ts
@@ -121,4 +121,14 @@ describe("resolveApiConfig on the server", () => {
     expect(config.kind).toBe("client");
     expect(config.apiKey).toBeUndefined();
   });
+
+  it("skips a wrong-kind backend env and uses a later server key", () => {
+    clearKeyEnvs();
+    process.env.APTOS_BUILD_API_KEY = "AG-WRONGTYPEFORBACKEND";
+    process.env.GEOMI_API_KEY = "aptoslabs_from_geomi";
+    const resolved = resolveApiKey();
+    expect(resolved.source).toBe("GEOMI_API_KEY");
+    expect(resolved.kind).toBe("server");
+    expect(resolveApiConfig().apiKey).toBe("aptoslabs_from_geomi");
+  });
 });

--- a/tests/unit/api-config.test.ts
+++ b/tests/unit/api-config.test.ts
@@ -19,6 +19,9 @@ const KEY_ENVS = [
   "VITE_GEOMI_INDEXER_URL",
   "GEOMI_FULLNODE_URL",
   "GEOMI_INDEXER_URL",
+  "APTOS_API_ORIGIN",
+  "VERCEL_URL",
+  "VERCEL_PROJECT_PRODUCTION_URL",
 ] as const;
 
 const originalEnv: Record<string, string | undefined> = {};
@@ -111,5 +114,37 @@ describe("resolveApiConfig", () => {
     const config = resolveApiConfig();
     expect(config.fullnodeUrl).toBe("http://localhost:8081/v1");
     expect(config.indexerUrl).toBe("http://localhost:8081/graphql");
+  });
+
+  it("does not send a Geomi client key from Node SSR", () => {
+    clearKeyEnvs();
+    process.env.VITE_APTOS_API_KEY_MAINNET = "AG-CLIENTKEYFROMSSR";
+    const config = resolveApiConfig();
+    expect(config.kind).toBe("client");
+    expect(config.key).toBe("AG-CLIENTKEYFROMSSR");
+    // Geomi client keys 401 with "Origin header is required" when Node
+    // SSR sends them without a browser Origin. Skip them server-side so
+    // the public endpoint is used instead of taking down the page.
+    expect(config.apiKey).toBeUndefined();
+    expect(config.requestOrigin).toBeUndefined();
+  });
+
+  it("sends a client key from SSR when an Origin can be attached", () => {
+    clearKeyEnvs();
+    process.env.VITE_APTOS_API_KEY_MAINNET = "AG-CLIENTKEYFROMSSR";
+    process.env.APTOS_API_ORIGIN = "https://governance-pearl.vercel.app";
+    const config = resolveApiConfig();
+    expect(config.apiKey).toBe("AG-CLIENTKEYFROMSSR");
+    expect(config.requestOrigin).toBe("https://governance-pearl.vercel.app");
+  });
+
+  it("does not guess Origin from Vercel hostnames, which may not be allowlisted", () => {
+    clearKeyEnvs();
+    process.env.VITE_APTOS_API_KEY_MAINNET = "AG-CLIENTKEYFROMSSR";
+    process.env.VERCEL_PROJECT_PRODUCTION_URL = "governance-pearl.vercel.app";
+    process.env.VERCEL_URL = "governance-pearl.vercel.app";
+    const config = resolveApiConfig();
+    expect(config.requestOrigin).toBeUndefined();
+    expect(config.apiKey).toBeUndefined();
   });
 });

--- a/tests/unit/api-config.test.ts
+++ b/tests/unit/api-config.test.ts
@@ -19,9 +19,6 @@ const KEY_ENVS = [
   "VITE_GEOMI_INDEXER_URL",
   "GEOMI_FULLNODE_URL",
   "GEOMI_INDEXER_URL",
-  "APTOS_API_ORIGIN",
-  "VERCEL_URL",
-  "VERCEL_PROJECT_PRODUCTION_URL",
 ] as const;
 
 const originalEnv: Record<string, string | undefined> = {};
@@ -60,34 +57,28 @@ describe("classifyApiKey", () => {
   });
 });
 
-describe("resolveApiKey", () => {
-  it("prefers APTOS_BUILD_API_KEY over legacy VITE_ names", () => {
+describe("resolveApiKey on the server", () => {
+  it("uses the backend key and ignores the frontend key", () => {
     clearKeyEnvs();
     process.env.APTOS_BUILD_API_KEY = "aptoslabs_server_key";
-    process.env.VITE_APTOS_API_KEY_MAINNET = "AG-CLIENTKEY";
+    process.env.VITE_APTOS_API_KEY = "AG-CLIENTKEY";
     const resolved = resolveApiKey();
     expect(resolved.source).toBe("APTOS_BUILD_API_KEY");
     expect(resolved.key).toBe("aptoslabs_server_key");
     expect(resolved.kind).toBe("server");
   });
 
-  it("falls back to the original Vite mainnet key name used on Vercel", () => {
+  it("does not use a VITE_ frontend key for SSR", () => {
     clearKeyEnvs();
     process.env.VITE_APTOS_API_KEY_MAINNET =
       "AG-FL4PYMZ1YX1LGAJCWP2R1ACYTYRCBY1GB";
+    process.env.VITE_APTOS_API_KEY = "AG-CLIENTKEY";
     const resolved = resolveApiKey();
-    expect(resolved.source).toBe("VITE_APTOS_API_KEY_MAINNET");
-    expect(resolved.kind).toBe("client");
+    expect(resolved.kind).toBe("none");
+    expect(resolved.key).toBeUndefined();
   });
 
-  it("accepts VITE_APTOS_BUILD_API_KEY as a legacy alias", () => {
-    clearKeyEnvs();
-    process.env.VITE_APTOS_BUILD_API_KEY = "aptoslabs_from_vite_build";
-    expect(resolveApiKey().source).toBe("VITE_APTOS_BUILD_API_KEY");
-    expect(resolveApiKey().kind).toBe("server");
-  });
-
-  it("accepts GEOMI_API_KEY as an alias", () => {
+  it("accepts GEOMI_API_KEY as a backend alias", () => {
     clearKeyEnvs();
     process.env.GEOMI_API_KEY = "aptoslabs_from_geomi";
     expect(resolveApiKey().source).toBe("GEOMI_API_KEY");
@@ -95,8 +86,8 @@ describe("resolveApiKey", () => {
   });
 });
 
-describe("resolveApiConfig", () => {
-  it("keeps Aptos Labs hosted endpoints when a Geomi/Aptos key is set", () => {
+describe("resolveApiConfig on the server", () => {
+  it("sends the backend key on Aptos Labs hosted endpoints", () => {
     clearKeyEnvs();
     process.env.APTOS_BUILD_API_KEY = "aptoslabs_server_key";
     const config = resolveApiConfig();
@@ -116,35 +107,18 @@ describe("resolveApiConfig", () => {
     expect(config.indexerUrl).toBe("http://localhost:8081/graphql");
   });
 
-  it("does not send a Geomi client key from Node SSR", () => {
+  it("does not send a frontend client key from Node SSR", () => {
     clearKeyEnvs();
-    process.env.VITE_APTOS_API_KEY_MAINNET = "AG-CLIENTKEYFROMSSR";
+    process.env.VITE_APTOS_API_KEY = "AG-CLIENTKEYFROMSSR";
+    const config = resolveApiConfig();
+    expect(config.apiKey).toBeUndefined();
+  });
+
+  it("does not send a client key even when it is stored as the backend env name", () => {
+    clearKeyEnvs();
+    process.env.APTOS_BUILD_API_KEY = "AG-WRONGTYPEFORBACKEND";
     const config = resolveApiConfig();
     expect(config.kind).toBe("client");
-    expect(config.key).toBe("AG-CLIENTKEYFROMSSR");
-    // Geomi client keys 401 with "Origin header is required" when Node
-    // SSR sends them without a browser Origin. Skip them server-side so
-    // the public endpoint is used instead of taking down the page.
-    expect(config.apiKey).toBeUndefined();
-    expect(config.requestOrigin).toBeUndefined();
-  });
-
-  it("sends a client key from SSR when an Origin can be attached", () => {
-    clearKeyEnvs();
-    process.env.VITE_APTOS_API_KEY_MAINNET = "AG-CLIENTKEYFROMSSR";
-    process.env.APTOS_API_ORIGIN = "https://governance-pearl.vercel.app";
-    const config = resolveApiConfig();
-    expect(config.apiKey).toBe("AG-CLIENTKEYFROMSSR");
-    expect(config.requestOrigin).toBe("https://governance-pearl.vercel.app");
-  });
-
-  it("does not guess Origin from Vercel hostnames, which may not be allowlisted", () => {
-    clearKeyEnvs();
-    process.env.VITE_APTOS_API_KEY_MAINNET = "AG-CLIENTKEYFROMSSR";
-    process.env.VERCEL_PROJECT_PRODUCTION_URL = "governance-pearl.vercel.app";
-    process.env.VERCEL_URL = "governance-pearl.vercel.app";
-    const config = resolveApiConfig();
-    expect(config.requestOrigin).toBeUndefined();
     expect(config.apiKey).toBeUndefined();
   });
 });

--- a/tests/unit/deployment-config.test.ts
+++ b/tests/unit/deployment-config.test.ts
@@ -33,9 +33,12 @@ describe("deployment config", () => {
     }
   });
 
-  it("exposes no client-side env vars, since config is server-only", () => {
+  it("keeps the backend key unprefixed and the frontend key Vite-prefixed", () => {
     const example = readFileSync(resolve(rootDir, ".env.example"), "utf8");
-    expect(example).not.toMatch(/^\s*VITE_/m);
+    expect(example).toMatch(/^APTOS_BUILD_API_KEY=/m);
+    expect(example).toMatch(/^VITE_APTOS_API_KEY=/m);
+    // A VITE_ backend key would inline the secret into the public bundle.
+    expect(example).not.toMatch(/^VITE_APTOS_BUILD_API_KEY=/m);
   });
 
   it("asks Vercel to cache SSR HTML briefly so Aptos is not hit on every request", () => {

--- a/tests/unit/indexer-client.test.ts
+++ b/tests/unit/indexer-client.test.ts
@@ -12,9 +12,6 @@ const ENV_NAMES = [
   "APTOS_API_KEY",
   "APTOS_INDEXER_URL",
   "VITE_GEOMI_INDEXER_URL",
-  "APTOS_API_ORIGIN",
-  "VERCEL_URL",
-  "VERCEL_PROJECT_PRODUCTION_URL",
 ] as const;
 
 const originalEnv: Record<string, string | undefined> = {};
@@ -83,9 +80,9 @@ describe("executeIndexerQuery", () => {
     );
   });
 
-  it("does not send a Geomi client key from the server", async () => {
+  it("does not send a frontend client key from the server", async () => {
     snapshotEnv();
-    process.env.VITE_APTOS_API_KEY_MAINNET = "AG-CLIENTKEYFROMSSR";
+    process.env.VITE_APTOS_API_KEY = "AG-CLIENTKEYFROMSSR";
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({data: {ok: true}}),
@@ -98,29 +95,6 @@ describe("executeIndexerQuery", () => {
       headers?: Record<string, string>;
     };
     expect(init.headers?.Authorization).toBeUndefined();
-  });
-
-  it("sends a client key with Origin when APTOS_API_ORIGIN is set", async () => {
-    snapshotEnv();
-    process.env.VITE_APTOS_API_KEY_MAINNET = "AG-CLIENTKEYFROMSSR";
-    process.env.APTOS_API_ORIGIN = "https://governance-pearl.vercel.app";
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({data: {ok: true}}),
-    });
-    globalThis.fetch = mockFetch as unknown as typeof fetch;
-
-    await executeIndexerQuery("query Foo { x }");
-
-    expect(mockFetch).toHaveBeenCalledWith(
-      "https://api.mainnet.aptoslabs.com/v1/graphql",
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          Authorization: "Bearer AG-CLIENTKEYFROMSSR",
-          Origin: "https://governance-pearl.vercel.app",
-        }),
-      }),
-    );
   });
 
   it("throws a descriptive error when the GraphQL response contains errors", async () => {

--- a/tests/unit/indexer-client.test.ts
+++ b/tests/unit/indexer-client.test.ts
@@ -12,6 +12,9 @@ const ENV_NAMES = [
   "APTOS_API_KEY",
   "APTOS_INDEXER_URL",
   "VITE_GEOMI_INDEXER_URL",
+  "APTOS_API_ORIGIN",
+  "VERCEL_URL",
+  "VERCEL_PROJECT_PRODUCTION_URL",
 ] as const;
 
 const originalEnv: Record<string, string | undefined> = {};
@@ -75,6 +78,46 @@ describe("executeIndexerQuery", () => {
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: "Bearer aptoslabs_server_key",
+        }),
+      }),
+    );
+  });
+
+  it("does not send a Geomi client key from the server", async () => {
+    snapshotEnv();
+    process.env.VITE_APTOS_API_KEY_MAINNET = "AG-CLIENTKEYFROMSSR";
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({data: {ok: true}}),
+    });
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    await executeIndexerQuery("query Foo { x }");
+
+    const init = mockFetch.mock.calls[0]?.[1] as {
+      headers?: Record<string, string>;
+    };
+    expect(init.headers?.Authorization).toBeUndefined();
+  });
+
+  it("sends a client key with Origin when APTOS_API_ORIGIN is set", async () => {
+    snapshotEnv();
+    process.env.VITE_APTOS_API_KEY_MAINNET = "AG-CLIENTKEYFROMSSR";
+    process.env.APTOS_API_ORIGIN = "https://governance-pearl.vercel.app";
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({data: {ok: true}}),
+    });
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    await executeIndexerQuery("query Foo { x }");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.mainnet.aptoslabs.com/v1/graphql",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer AG-CLIENTKEYFROMSSR",
+          Origin: "https://governance-pearl.vercel.app",
         }),
       }),
     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The live proposals list (`/?page=0&status=all`) rendered TanStack’s “Something went wrong!” boundary and returned HTTP 500.

**Cause:** SSR was sending a Geomi **client** API key (`AG-…`, often from a legacy `VITE_*` Vercel secret) without an `Origin` header. Geomi then 401s with `Unauthorized: Origin header is required`, the route loader throws, and the page never renders.

**Fix:** use two keys, not a client key plus an Origin workaround.

| Side | Env | Key type | Used for |
| --- | --- | --- | --- |
| Backend | `APTOS_BUILD_API_KEY` (also `GEOMI_API_KEY`, `APTOS_API_KEY`) | `aptoslabs_…` | SSR / server functions |
| Frontend | `VITE_APTOS_API_KEY` (also `VITE_APTOS_API_KEY_MAINNET`, `VITE_GEOMI_API_KEY`) | `AG-…` | Wallet adapter and browser Aptos SDK calls |

The server never sends `AG-…` keys. The browser never sends `aptoslabs_…` keys. Mixing those is what 401'd SSR and would leak a server secret if inlined. Wrong-kind values are skipped so a later alias of the correct type still works.

Loader/API failures still render in-page with retry instead of the generic error boundary.

**Vercel:** set both `APTOS_BUILD_API_KEY` (server key) and `VITE_APTOS_API_KEY` (client key, origin allowlisted). Copy any existing `VITE_APTOS_BUILD_API_KEY` value to unprefixed `APTOS_BUILD_API_KEY` and delete the `VITE_` name (it is no longer read, and would inline the server secret). Without the backend key, SSR uses the public endpoint (page should load; rate limits possible). Without the frontend key, wallet/browser Aptos calls are unauthenticated.

Do not set `APTOS_API_ORIGIN` — that approach was dropped.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-053b6677-61a4-49ea-8655-bf5a840d711f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-053b6677-61a4-49ea-8655-bf5a840d711f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

