### PR TITLE
Fix Dependabot alerts for nitro and uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,11 +42,16 @@
     "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^6.0.1",
     "jsdom": "^30.0.1",
-    "nitro": "^3.0.260311-beta",
+    "nitro": "3.0.260429-beta",
     "tailwindcss": "^4.3.3",
     "typescript": "^5.7.2",
     "vite": "^8.0.14",
     "vitest": "^3.2.4"
   },
-  "packageManager": "pnpm@10.33.2"
+  "packageManager": "pnpm@10.33.2",
+  "pnpm": {
+    "overrides": {
+      "uuid": "11.1.1"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  uuid: 11.1.1
+
 importers:
 
   .:
@@ -70,8 +73,8 @@ importers:
         specifier: ^30.0.1
         version: 30.0.1(@noble/hashes@2.3.0)
       nitro:
-        specifier: ^3.0.260311-beta
-        version: 3.0.260311-beta(jiti@2.7.0)(rollup@4.62.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0))
+        specifier: 3.0.260429-beta
+        version: 3.0.260429-beta(jiti@2.7.0)(rollup@4.62.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0))
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -1906,19 +1909,22 @@ packages:
   nf3@0.3.24:
     resolution: {integrity: sha512-HxLK4bo+5jNsEETZp4w3tJblHOA9MCBY14IN9nZJJV8JDxt9yNIYxuBuLMjTAR5GFa3HL61+8VQDUrXv3/C8fw==}
 
-  nitro@3.0.260311-beta:
-    resolution: {integrity: sha512-0o0fJ9LUh4WKUqJNX012jyieUOtMCnadkNDWr0mHzdraoHpJP/1CGNefjRyZyMXSpoJfwoWdNEZu2iGf35TUvQ==}
+  nitro@3.0.260429-beta:
+    resolution: {integrity: sha512-KweLVCUN5X9v9g+4yxAyRcz3FcOlnjmt9FyrAIWDxJETJmNT7I0JV0clgsONjo2nI0U5gwedXYA3RaNtF5XWzg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
+      '@vercel/queue': ^0.1.6
       dotenv: '*'
       giget: '*'
       jiti: ^2.6.1
-      rollup: ^4.59.0
-      vite: ^7 || ^8 || >=8.0.0-0
+      rollup: ^4.60.2
+      vite: ^7 || ^8
       xml2js: ^0.6.2
-      zephyr-agent: ^0.1.15
+      zephyr-agent: ^0.2.0
     peerDependenciesMeta:
+      '@vercel/queue':
+        optional: true
       dotenv:
         optional: true
       giget:
@@ -2235,9 +2241,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   vite-node@3.2.4:
@@ -2440,7 +2445,7 @@ snapshots:
       '@aptos-labs/ts-sdk': 7.3.0
       '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@7.3.0)(@wallet-standard/core@1.1.2)
       '@telegram-apps/bridge': 1.9.2
-      uuid: 9.0.1
+      uuid: 11.1.1
     transitivePeerDependencies:
       - '@wallet-standard/core'
 
@@ -2785,7 +2790,7 @@ snapshots:
       '@identity-connect/crypto': 0.3.1(@aptos-labs/ts-sdk@7.3.0)(@wallet-standard/core@1.1.2)
       '@identity-connect/wallet-api': 0.2.0(@aptos-labs/ts-sdk@7.3.0)
       axios: 1.19.0
-      uuid: 9.0.1
+      uuid: 11.1.1
     transitivePeerDependencies:
       - '@telegram-apps/bridge'
       - '@wallet-standard/core'
@@ -4015,7 +4020,7 @@ snapshots:
 
   nf3@0.3.24: {}
 
-  nitro@3.0.260311-beta(jiti@2.7.0)(rollup@4.62.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)):
+  nitro@3.0.260429-beta(jiti@2.7.0)(rollup@4.62.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.12(srvx@0.11.22)
@@ -4039,7 +4044,6 @@ snapshots:
       - '@electric-sql/pglite'
       - '@libsql/client'
       - '@netlify/runtime'
-      - '@vercel/queue'
       - better-sqlite3
       - drizzle-orm
       - miniflare
@@ -4298,7 +4302,7 @@ snapshots:
     dependencies:
       react: 19.2.8
 
-  uuid@9.0.1: {}
+  uuid@11.1.1: {}
 
   vite-node@3.2.4(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0):
     dependencies:

--- a/tests/unit/deployment-config.test.ts
+++ b/tests/unit/deployment-config.test.ts
@@ -55,4 +55,26 @@ describe("deployment config", () => {
       expect(cacheControl?.value).toBe(PUBLIC_PAGE_CACHE_CONTROL);
     }
   });
+
+  it("uses patched nitro and uuid versions for known GHSA advisories", () => {
+    const pkg = readJson("package.json") as {
+      devDependencies: {nitro: string};
+      pnpm?: {overrides?: Record<string, string>};
+    };
+
+    const nitroSpecifier = pkg.devDependencies.nitro.replace(/^\^/, "");
+    const nitroBuild = Number(
+      nitroSpecifier.match(/^3\.0\.(\d+)-beta$/)?.[1] ?? 0,
+    );
+    // GHSA-5w89-w975-hf9q / GHSA-9phm-9p8f-hw5m: nitro < 3.0.260429-beta
+    expect(nitroBuild).toBeGreaterThanOrEqual(260429);
+
+    // GHSA-w5hq-g745-h8pq: uuid < 11.1.1. 11.1.1 keeps CJS require()
+    // for @aptos-connect/web-transport; uuid 14 is ESM-only.
+    expect(pkg.pnpm?.overrides?.uuid).toBe("11.1.1");
+
+    const lock = readFileSync(resolve(rootDir, "pnpm-lock.yaml"), "utf8");
+    expect(lock).toMatch(/^ {2}uuid@11\.1\.1:/m);
+    expect(lock).not.toMatch(/^ {2}uuid@(?:[0-9]\.|10\.|11\.0\.|11\.1\.0)/m);
+  });
 });

--- a/tests/unit/deployment-config.test.ts
+++ b/tests/unit/deployment-config.test.ts
@@ -62,18 +62,16 @@ describe("deployment config", () => {
       pnpm?: {overrides?: Record<string, string>};
     };
 
-    const nitroSpecifier = pkg.devDependencies.nitro.replace(/^\^/, "");
-    const nitroBuild = Number(
-      nitroSpecifier.match(/^3\.0\.(\d+)-beta$/)?.[1] ?? 0,
-    );
-    // GHSA-5w89-w975-hf9q / GHSA-9phm-9p8f-hw5m: nitro < 3.0.260429-beta
-    expect(nitroBuild).toBeGreaterThanOrEqual(260429);
+    // GHSA-5w89-w975-hf9q / GHSA-9phm-9p8f-hw5m: nitro < 3.0.260429-beta.
+    // Pin the first patched 3.x beta; later betas (260610) 500 SSR on Vite 8.2.
+    expect(pkg.devDependencies.nitro).toBe("3.0.260429-beta");
 
     // GHSA-w5hq-g745-h8pq: uuid < 11.1.1. 11.1.1 keeps CJS require()
     // for @aptos-connect/web-transport; uuid 14 is ESM-only.
     expect(pkg.pnpm?.overrides?.uuid).toBe("11.1.1");
 
     const lock = readFileSync(resolve(rootDir, "pnpm-lock.yaml"), "utf8");
+    expect(lock).toMatch(/^ {2}nitro@3\.0\.260429-beta:/m);
     expect(lock).toMatch(/^ {2}uuid@11\.1\.1:/m);
     expect(lock).not.toMatch(/^ {2}uuid@(?:[0-9]\.|10\.|11\.0\.|11\.1\.0)/m);
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

GitHub Dependabot / GHSA advisories were open against the lockfile:

- **nitro@3.0.260311-beta** — [GHSA-5w89-w975-hf9q](https://github.com/advisories/GHSA-5w89-w975-hf9q) (CVE-2026-44373, proxy path traversal) and [GHSA-9phm-9p8f-hw5m](https://github.com/advisories/GHSA-9phm-9p8f-hw5m) (CVE-2026-44372, open redirect). Patched in `3.0.260429-beta`.
- **uuid@9.0.1** (transitive via Aptos Connect) — [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq). Patched in `11.1.1`.

## Changes

- Pin `nitro` to `3.0.260429-beta` (first patched 3.x beta). Later betas (`3.0.260610-beta`) have a known TanStack Start + Vite 8.2 SSR `ssr_exports` failure.
- Add a pnpm override so `uuid` resolves to `11.1.1` (last CJS-compatible patched line; uuid 14 is ESM-only and would break `require("uuid")` in `@aptos-connect/web-transport`).
- Add a lockfile regression test that asserts these exact pins so they do not drift back.

This app does not use Nitro `routeRules` proxy/redirect wildcards, so the Nitro CVEs were not directly exploitable here, but Dependabot still flags the resolved package versions.

## Verification

- `pnpm audit`: no known vulnerabilities
- `pnpm typecheck`, `pnpm test` (149), `pnpm lint`, `pnpm build`: pass
- Production server SSR: `/`, `/proposal/1`, `/delegation` return HTTP 200 HTML
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89cb0139-227f-447b-8274-cc369b3429a0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89cb0139-227f-447b-8274-cc369b3429a0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

