### PR TITLE
Connect the hero squiggle to the divider lines

### DIFF
--- a/src/components/HeroDivider.tsx
+++ b/src/components/HeroDivider.tsx
@@ -1,6 +1,6 @@
 export function HeroDivider() {
   return (
-    <div className="mb-8 mt-2 flex items-center text-[var(--color-border)]">
+    <div className="mb-8 mt-2 flex items-stretch text-[var(--color-border)]">
       <div className="mt-[14px] flex-1 border-y border-current" />
       <svg width="52" height="34" aria-hidden="true">
         <path

--- a/tests/unit/HeroDivider.test.tsx
+++ b/tests/unit/HeroDivider.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import {cleanup, render} from "@testing-library/react";
+import {afterEach, describe, expect, it} from "vitest";
+import {HeroDivider} from "~/components/HeroDivider";
+
+describe("HeroDivider", () => {
+  afterEach(cleanup);
+
+  it("stretches the double-line rails so they meet both squiggle endpoints", () => {
+    const {container} = render(<HeroDivider />);
+    const root = container.firstElementChild as HTMLElement;
+    const classes = root.className.split(/\s+/);
+
+    // Default flex alignment is stretch; items-center collapses the empty
+    // rails into a 2px bar that no longer meets the SVG path endpoints.
+    expect(classes).toContain("flex");
+    expect(classes).toContain("items-stretch");
+    expect(classes).not.toContain("items-center");
+
+    const [leftRail, svg, rightRail] = Array.from(root.children);
+    expect(leftRail.className.split(/\s+/)).toEqual(
+      expect.arrayContaining(["mt-[14px]", "flex-1", "border-y"]),
+    );
+    expect(rightRail.className.split(/\s+/)).toEqual(
+      expect.arrayContaining(["mb-[14px]", "flex-1", "border-y"]),
+    );
+    expect(svg.tagName.toLowerCase()).toBe("svg");
+    expect(svg).toHaveAttribute("width", "52");
+    expect(svg).toHaveAttribute("height", "34");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The hero divider is meant to be two parallel lines that twist through the center squiggle, matching the original Aptos governance `DividerHero`.

`items-center` vertically centered the empty `border-y` rails. With no height of their own, those rails collapsed into a 2px bar, so they no longer lined up with the SVG path endpoints at `y=14.5` / `y=33.5` on the left and `y=0.5` / `y=19.5` on the right.

This restores flex stretch (the original MUI layout) so each rail is 20px tall inside the 34px squiggle and both borders meet the curves.

**Before (`items-center`) vs after (`items-stretch`):**

[Hero divider before and after: centered rails miss the squiggle, stretched rails meet both path endpoints](https://cursor.com/agents/bc-9eb1d8dd-8b73-42a3-89e5-0efcc842a679/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdivider-compare.png)

**Homepage close-up after the fix:**

[Homepage hero divider with double lines joining the center squiggle](https://cursor.com/agents/bc-9eb1d8dd-8b73-42a3-89e5-0efcc842a679/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhome-divider-closeup.png)

## Test plan
- Unit test asserts the divider uses `items-stretch` rather than `items-center`, and keeps the original 14px rail offsets and 52×34 SVG.
- Visual: homepage (desktop + mobile) and My Delegation — the double lines join the squiggle with no gap.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9eb1d8dd-8b73-42a3-89e5-0efcc842a679?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9eb1d8dd-8b73-42a3-89e5-0efcc842a679&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

