### PR TITLE
Add a Report Issue button that opens a GitHub issue

### DIFF
--- a/src/components/ReportIssueButton.tsx
+++ b/src/components/ReportIssueButton.tsx
@@ -1,0 +1,24 @@
+import {useEffect, useState} from "react";
+import {githubNewIssueUrl} from "~/lib/github-issue";
+
+const DEFAULT_CLASS =
+  "whitespace-nowrap rounded border border-[var(--color-border)] px-3 py-1 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-row-hover)]";
+
+export function ReportIssueButton({className}: {className?: string}) {
+  const [href, setHref] = useState(() => githubNewIssueUrl());
+
+  useEffect(() => {
+    setHref(githubNewIssueUrl(window.location.href));
+  }, []);
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={className ? `${DEFAULT_CLASS} ${className}` : DEFAULT_CLASS}
+    >
+      Report Issue
+    </a>
+  );
+}

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -4,6 +4,7 @@ import githubIcon from "~/assets/svg/github.svg";
 import mediumIcon from "~/assets/svg/medium.svg";
 import twitterIcon from "~/assets/svg/twitter.svg";
 import {BrandMark} from "~/components/BrandMark";
+import {ReportIssueButton} from "~/components/ReportIssueButton";
 import {PAGE_SHELL_WIDTH_CLASS} from "~/lib/layout";
 
 const SOCIAL = [
@@ -48,6 +49,7 @@ export function SiteFooter() {
           © {new Date().getFullYear()}{" "}
           <span className="whitespace-nowrap">Aptos Foundation</span>
         </p>
+        <ReportIssueButton />
         <div className="flex items-center gap-5 md:ml-auto">
           {SOCIAL.map((link) => (
             <a

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,6 +1,7 @@
 import {Link} from "@tanstack/react-router";
 import logoIcon from "~/assets/svg/aptos_logo_icon.svg";
 import {BrandMark} from "~/components/BrandMark";
+import {ReportIssueButton} from "~/components/ReportIssueButton";
 import {ThemeToggle} from "~/components/ThemeToggle";
 import {WalletConnectButton} from "~/components/WalletConnectButton";
 import {PAGE_SHELL_WIDTH_CLASS} from "~/lib/layout";
@@ -34,6 +35,7 @@ export function SiteHeader() {
         >
           My Delegation
         </Link>
+        <ReportIssueButton className="hidden sm:inline-flex" />
         <ThemeToggle />
         <div className="sm:hidden">
           <WalletConnectButton />

--- a/src/lib/github-issue.ts
+++ b/src/lib/github-issue.ts
@@ -1,0 +1,13 @@
+export const GITHUB_REPO_URL = "https://github.com/aptos-labs/governance";
+export const GITHUB_NEW_ISSUE_URL = `${GITHUB_REPO_URL}/issues/new`;
+
+export function githubNewIssueUrl(pageUrl?: string): string {
+  const url = new URL(GITHUB_NEW_ISSUE_URL);
+  const sections = ["## Describe the issue", "", ""];
+  const trimmed = pageUrl?.trim();
+  if (trimmed) {
+    sections.push("## Page", "", trimmed, "");
+  }
+  url.searchParams.set("body", sections.join("\n"));
+  return url.toString();
+}

--- a/tests/unit/ReportIssueButton.test.tsx
+++ b/tests/unit/ReportIssueButton.test.tsx
@@ -1,0 +1,24 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import {cleanup, render, screen, waitFor} from "@testing-library/react";
+import {afterEach, describe, expect, it} from "vitest";
+import {ReportIssueButton} from "~/components/ReportIssueButton";
+import {GITHUB_NEW_ISSUE_URL} from "~/lib/github-issue";
+
+describe("ReportIssueButton", () => {
+  afterEach(cleanup);
+
+  it("opens a GitHub new-issue form in a new tab", async () => {
+    render(<ReportIssueButton />);
+    const link = screen.getByRole("link", {name: "Report Issue"});
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    expect(link.getAttribute("href")).toContain(GITHUB_NEW_ISSUE_URL);
+
+    await waitFor(() => {
+      const href = link.getAttribute("href") ?? "";
+      const body = new URL(href).searchParams.get("body") ?? "";
+      expect(body).toContain(window.location.href);
+    });
+  });
+});

--- a/tests/unit/SiteFooter.test.tsx
+++ b/tests/unit/SiteFooter.test.tsx
@@ -1,0 +1,17 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import {cleanup, render, screen} from "@testing-library/react";
+import {afterEach, describe, expect, it} from "vitest";
+import {SiteFooter} from "~/components/SiteFooter";
+import {GITHUB_NEW_ISSUE_URL} from "~/lib/github-issue";
+
+describe("SiteFooter", () => {
+  afterEach(cleanup);
+
+  it("includes a Report Issue button that opens GitHub", () => {
+    render(<SiteFooter />);
+    const link = screen.getByRole("link", {name: "Report Issue"});
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link.getAttribute("href")).toContain(GITHUB_NEW_ISSUE_URL);
+  });
+});

--- a/tests/unit/github-issue.test.ts
+++ b/tests/unit/github-issue.test.ts
@@ -1,0 +1,20 @@
+import {describe, expect, it} from "vitest";
+import {GITHUB_NEW_ISSUE_URL, githubNewIssueUrl} from "~/lib/github-issue";
+
+describe("githubNewIssueUrl", () => {
+  it("opens a new issue on aptos-labs/governance", () => {
+    const href = githubNewIssueUrl();
+    expect(href.startsWith(`${GITHUB_NEW_ISSUE_URL}?`)).toBe(true);
+    expect(href).toContain("github.com/aptos-labs/governance/issues/new");
+    expect(new URL(href).searchParams.get("body")).toContain(
+      "Describe the issue",
+    );
+  });
+
+  it("includes the current page in the issue body", () => {
+    const pageUrl = "https://governance.aptosfoundation.org/proposal/142";
+    const href = githubNewIssueUrl(pageUrl);
+    const body = new URL(href).searchParams.get("body") ?? "";
+    expect(body).toContain(pageUrl);
+  });
+});

--- a/tests/unit/layout.test.ts
+++ b/tests/unit/layout.test.ts
@@ -27,4 +27,14 @@ describe("page shell width", () => {
       expect(source, relative).not.toContain("max-w-7xl");
     }
   });
+
+  it("places Report Issue in the header and footer chrome", () => {
+    for (const relative of [
+      "src/components/SiteHeader.tsx",
+      "src/components/SiteFooter.tsx",
+    ]) {
+      const source = readFileSync(path.join(rootDir, relative), "utf8");
+      expect(source, relative).toContain("ReportIssueButton");
+    }
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a **Report Issue** control that opens a new GitHub issue against [`aptos-labs/governance`](https://github.com/aptos-labs/governance/issues/new).

- Header (sm and up): bordered button next to My Delegation
- Footer: always visible, including on mobile where the header control is hidden so it does not crowd the wallet button
- After mount, the issue body is pre-filled with the current page URL

The link uses `target="_blank"` and `rel="noopener noreferrer"`. Unauthenticated users are sent through GitHub login, then to the new-issue form (GitHub’s normal `issues/new` flow).

Verified locally: `pnpm typecheck`, `pnpm test` (155), `pnpm lint`, `pnpm build`. SSR HTML on `/`, `/delegation`, and `/proposal/1` each includes two Report Issue links pointing at `github.com/aptos-labs/governance/issues/new`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a633c1a1-cb46-40f3-a399-394302c7b089?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a633c1a1-cb46-40f3-a399-394302c7b089&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

