### PR TITLE
Show AIP-62 wallet icons next to names in the connect picker

### DIFF
--- a/src/components/WalletConnectButton.tsx
+++ b/src/components/WalletConnectButton.tsx
@@ -1,8 +1,24 @@
 import {useWallet, type WalletInfo} from "@aptos-labs/wallet-adapter-react";
 import {useState} from "react";
 import {AddressChip} from "~/components/AddressChip";
+import {aip62WalletIconSrc} from "~/lib/wallet/aip62-icon";
 
 const FEATURED_WALLETS = ["Petra", "Petra Web"];
+
+function WalletIcon({icon}: {icon: unknown}) {
+  const src = aip62WalletIconSrc(icon);
+  if (!src) return null;
+  return (
+    <img
+      src={src}
+      alt=""
+      width={20}
+      height={20}
+      className="h-5 w-5 shrink-0 rounded object-contain"
+      aria-hidden="true"
+    />
+  );
+}
 
 function sortWithFeaturedFirst(wallets: readonly WalletInfo[]) {
   return [...wallets].sort((a, b) => {
@@ -46,7 +62,7 @@ export function WalletConnectButton() {
       {pickerOpen && (
         <ul
           role="menu"
-          className="absolute right-0 z-30 mt-2 w-48 rounded-lg border border-[var(--color-border-light)] bg-[var(--color-paper)] p-1 shadow-lg"
+          className="absolute right-0 z-30 mt-2 min-w-56 rounded-lg border border-[var(--color-border-light)] bg-[var(--color-paper)] p-1 shadow-lg"
         >
           {sortWithFeaturedFirst(wallets).map((wallet) => (
             <li key={wallet.name} role="none">
@@ -57,9 +73,10 @@ export function WalletConnectButton() {
                   connect(wallet.name);
                   setPickerOpen(false);
                 }}
-                className="w-full rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-[var(--color-border-light)]"
+                className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-[var(--color-border-light)]"
               >
-                {wallet.name}
+                <WalletIcon icon={wallet.icon} />
+                <span>{wallet.name}</span>
               </button>
             </li>
           ))}

--- a/src/lib/wallet/aip62-icon.ts
+++ b/src/lib/wallet/aip62-icon.ts
@@ -1,0 +1,12 @@
+/**
+ * AIP-62 wallet icons are data URIs with a fixed media type and
+ * base64 payload. See aptos-foundation/AIPs aip-62 (AptosWallet.icon)
+ * and @aptos-labs/wallet-standard AptosWallet.
+ */
+const AIP62_ICON =
+  /^data:image\/(?:svg\+xml|webp|png|gif);base64,[A-Za-z0-9+/]+=*$/;
+
+export function aip62WalletIconSrc(icon: unknown): string | undefined {
+  if (typeof icon !== "string" || !AIP62_ICON.test(icon)) return undefined;
+  return icon;
+}

--- a/tests/unit/WalletConnectButton.test.tsx
+++ b/tests/unit/WalletConnectButton.test.tsx
@@ -12,6 +12,10 @@ vi.mock("@aptos-labs/wallet-adapter-react", async () => {
 
 const mockedUseWallet = vi.mocked(useWallet);
 
+const PETRA_ICON =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+const NIGHTLY_ICON = "data:image/svg+xml;base64,PHN2Zy8+";
+
 describe("WalletConnectButton", () => {
   afterEach(cleanup);
 
@@ -69,6 +73,39 @@ describe("WalletConnectButton", () => {
     fireEvent.click(screen.getByRole("button", {name: /connect wallet/i}));
     fireEvent.click(screen.getByRole("menuitem", {name: "Petra"}));
     expect(connect).toHaveBeenCalledWith("Petra");
+  });
+
+  it("renders each wallet's AIP-62 icon next to its name", () => {
+    mockedUseWallet.mockReturnValue({
+      connected: false,
+      account: null,
+      wallets: [
+        {name: "Petra", icon: PETRA_ICON, readyState: "Installed"},
+        {name: "Nightly", icon: NIGHTLY_ICON, readyState: "Installed"},
+        {
+          name: "Unknown",
+          icon: "https://example.com/wallet.png",
+          readyState: "Installed",
+        },
+      ],
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    } as never);
+
+    render(<WalletConnectButton />);
+    fireEvent.click(screen.getByRole("button", {name: /connect wallet/i}));
+
+    const petra = screen.getByRole("menuitem", {name: "Petra"});
+    const petraIcon = petra.querySelector("img");
+    expect(petraIcon).toHaveAttribute("src", PETRA_ICON);
+    expect(petraIcon).toHaveAttribute("alt", "");
+
+    const nightly = screen.getByRole("menuitem", {name: "Nightly"});
+    expect(nightly.querySelector("img")).toHaveAttribute("src", NIGHTLY_ICON);
+
+    expect(
+      screen.getByRole("menuitem", {name: "Unknown"}).querySelector("img"),
+    ).toBeNull();
   });
 
   it("shows the truncated address and a disconnect control when connected", () => {

--- a/tests/unit/aip62-icon.test.ts
+++ b/tests/unit/aip62-icon.test.ts
@@ -1,0 +1,28 @@
+import {describe, expect, it} from "vitest";
+import {aip62WalletIconSrc} from "~/lib/wallet/aip62-icon";
+
+const PNG =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+describe("aip62WalletIconSrc", () => {
+  it("accepts AIP-62 data URIs", () => {
+    expect(aip62WalletIconSrc(PNG)).toBe(PNG);
+    expect(aip62WalletIconSrc("data:image/svg+xml;base64,PHN2Zy8+")).toBe(
+      "data:image/svg+xml;base64,PHN2Zy8+",
+    );
+    expect(aip62WalletIconSrc("data:image/webp;base64,AAAA")).toBe(
+      "data:image/webp;base64,AAAA",
+    );
+    expect(aip62WalletIconSrc("data:image/gif;base64,AAAA")).toBe(
+      "data:image/gif;base64,AAAA",
+    );
+  });
+
+  it("rejects missing, remote, or non-AIP-62 icons", () => {
+    expect(aip62WalletIconSrc(undefined)).toBeUndefined();
+    expect(aip62WalletIconSrc("")).toBeUndefined();
+    expect(aip62WalletIconSrc("https://example.com/petra.png")).toBeUndefined();
+    expect(aip62WalletIconSrc("data:text/plain;base64,AAAA")).toBeUndefined();
+    expect(aip62WalletIconSrc("data:image/jpeg;base64,AAAA")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The Connect Wallet menu listed AIP-62 wallets by name only. Each wallet already advertises an icon as a data URI (`data:image/{svg+xml|webp|png|gif};base64,...`) per AIP-62 / `@aptos-labs/wallet-standard`.

This change renders that icon beside the wallet name (Petra, Nightly, Petra Web, etc.) so the picker matches how wallets identify themselves. Icons that are missing or not AIP-62 data URIs are omitted so the name still remains the accessible label.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (158 tests)
- [x] `pnpm build`
- [x] Opened the app, clicked **Connect Wallet**, and confirmed Petra, Nightly, Backpack, Google, and Apple each show their AIP-62 icon next to the name
- [x] Confirmed wallets without a valid AIP-62 icon still appear by name (unit test)
- [x] Confirmed choosing a wallet still connects as before (unit test)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39d9772a-d90e-4edb-8222-0f9189fa4df9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39d9772a-d90e-4edb-8222-0f9189fa4df9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

