### PR TITLE
Add Vercel Web Analytics and Speed Insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,11 @@ Start server functions, so it cannot be deployed to a static host.
 install/build commands so the settings do not depend on dashboard state. Set
 the variables above in the Vercel project's environment variable settings.
 
-Vercel Web Analytics is wired in the document shell via `@vercel/analytics`.
-Enable **Web Analytics** on the project in the Vercel dashboard so
-`/_vercel/insights/*` is served after the next deploy.
+Vercel Web Analytics and Speed Insights are wired in the document shell via
+`@vercel/analytics` and `@vercel/speed-insights`. Enable **Web Analytics**
+and **Speed Insights** on the project in the Vercel dashboard so
+`/_vercel/insights/*` and `/_vercel/speed-insights/*` are served after the
+next deploy.
 
 ## Quality Gates
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ Start server functions, so it cannot be deployed to a static host.
 install/build commands so the settings do not depend on dashboard state. Set
 the variables above in the Vercel project's environment variable settings.
 
+Vercel Web Analytics is wired in the document shell via `@vercel/analytics`.
+Enable **Web Analytics** on the project in the Vercel dashboard so
+`/_vercel/insights/*` is served after the next deploy.
+
 ## Quality Gates
 
 Run before creating a PR:

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@tanstack/react-router": "^1.170.31",
     "@tanstack/react-router-ssr-query": "^1.167.1",
     "@tanstack/react-start": "^1.168.48",
+    "@vercel/analytics": "^2.0.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@tanstack/react-router-ssr-query": "^1.167.1",
     "@tanstack/react-start": "^1.168.48",
     "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "zod": "^4.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(react@19.2.8)
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0(react@19.2.8)
       react:
         specifier: ^19.0.0
         version: 19.2.8
@@ -1192,6 +1195,32 @@ packages:
     peerDependenciesMeta:
       '@remix-run/react':
         optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
       '@sveltejs/kit':
         optional: true
       next:
@@ -3430,6 +3459,10 @@ snapshots:
       csstype: 3.2.3
 
   '@vercel/analytics@2.0.1(react@19.2.8)':
+    optionalDependencies:
+      react: 19.2.8
+
+  '@vercel/speed-insights@2.0.0(react@19.2.8)':
     optionalDependencies:
       react: 19.2.8
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@tanstack/react-start':
         specifier: ^1.168.48
         version: 1.168.48(crossws@0.4.12(srvx@0.11.22))(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0))
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(react@19.2.8)
       react:
         specifier: ^19.0.0
         version: 19.2.8
@@ -1174,6 +1177,35 @@ packages:
 
   '@types/react@19.2.18':
     resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitejs/plugin-react@6.1.0':
     resolution: {integrity: sha512-qd2BzUBehkov86WFhg0JkEFEYyCLG9uPCe6qWTY/kRlss9OvJrOF2UbIWT7p+8IzZHkEu0DNGHc4HSv+JdDLsw==}
@@ -3396,6 +3428,10 @@ snapshots:
   '@types/react@19.2.18':
     dependencies:
       csstype: 3.2.3
+
+  '@vercel/analytics@2.0.1(react@19.2.8)':
+    optionalDependencies:
+      react: 19.2.8
 
   '@vitejs/plugin-react@6.1.0(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0))':
     dependencies:

--- a/src/components/VercelAnalytics.tsx
+++ b/src/components/VercelAnalytics.tsx
@@ -1,5 +1,6 @@
 import {useParams, useRouterState} from "@tanstack/react-router";
 import {Analytics} from "@vercel/analytics/react";
+import {SpeedInsights} from "@vercel/speed-insights/react";
 import {analyticsRouteFromPath} from "~/lib/analytics-route";
 
 export function VercelAnalytics() {
@@ -10,6 +11,9 @@ export function VercelAnalytics() {
   const route = analyticsRouteFromPath(pathname, params);
 
   return (
-    <Analytics framework="tanstack-start" path={pathname} route={route} />
+    <>
+      <Analytics framework="tanstack-start" path={pathname} route={route} />
+      <SpeedInsights framework="tanstack-start" route={route} />
+    </>
   );
 }

--- a/src/components/VercelAnalytics.tsx
+++ b/src/components/VercelAnalytics.tsx
@@ -1,0 +1,15 @@
+import {useParams, useRouterState} from "@tanstack/react-router";
+import {Analytics} from "@vercel/analytics/react";
+import {analyticsRouteFromPath} from "~/lib/analytics-route";
+
+export function VercelAnalytics() {
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  });
+  const params = useParams({strict: false});
+  const route = analyticsRouteFromPath(pathname, params);
+
+  return (
+    <Analytics framework="tanstack-start" path={pathname} route={route} />
+  );
+}

--- a/src/lib/analytics-route.ts
+++ b/src/lib/analytics-route.ts
@@ -1,0 +1,12 @@
+/** Map a concrete pathname plus route params to a Vercel Analytics route pattern. */
+export function analyticsRouteFromPath(
+  pathname: string,
+  params: Record<string, string | undefined>,
+): string {
+  let route = pathname;
+  for (const [key, value] of Object.entries(params)) {
+    if (!value) continue;
+    route = route.replace(`/${value}`, `/[${key}]`);
+  }
+  return route;
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -6,6 +6,7 @@ import {
 } from "@tanstack/react-router";
 import {SiteFooter} from "~/components/SiteFooter";
 import {SiteHeader} from "~/components/SiteHeader";
+import {VercelAnalytics} from "~/components/VercelAnalytics";
 import {PAGE_SHELL_WIDTH_CLASS} from "~/lib/layout";
 import {AppWalletProvider} from "~/lib/wallet/provider";
 import appCss from "~/styles/app.css?url";
@@ -75,6 +76,7 @@ function RootDocument({children}: {children: React.ReactNode}) {
       <body>
         <script dangerouslySetInnerHTML={{__html: THEME_BOOTSTRAP}} />
         {children}
+        <VercelAnalytics />
         <Scripts />
       </body>
     </html>

--- a/tests/unit/analytics-route.test.ts
+++ b/tests/unit/analytics-route.test.ts
@@ -1,0 +1,15 @@
+import {describe, expect, it} from "vitest";
+import {analyticsRouteFromPath} from "~/lib/analytics-route";
+
+describe("analyticsRouteFromPath", () => {
+  it("leaves static paths unchanged", () => {
+    expect(analyticsRouteFromPath("/", {})).toBe("/");
+    expect(analyticsRouteFromPath("/delegation", {})).toBe("/delegation");
+  });
+
+  it("replaces dynamic segments so proposal pages group together", () => {
+    expect(
+      analyticsRouteFromPath("/proposal/42", {proposalId: "42"}),
+    ).toBe("/proposal/[proposalId]");
+  });
+});

--- a/tests/unit/analytics-route.test.ts
+++ b/tests/unit/analytics-route.test.ts
@@ -8,8 +8,8 @@ describe("analyticsRouteFromPath", () => {
   });
 
   it("replaces dynamic segments so proposal pages group together", () => {
-    expect(
-      analyticsRouteFromPath("/proposal/42", {proposalId: "42"}),
-    ).toBe("/proposal/[proposalId]");
+    expect(analyticsRouteFromPath("/proposal/42", {proposalId: "42"})).toBe(
+      "/proposal/[proposalId]",
+    );
   });
 });

--- a/tests/unit/deployment-config.test.ts
+++ b/tests/unit/deployment-config.test.ts
@@ -63,7 +63,10 @@ describe("deployment config", () => {
     expect(pkg.dependencies["@vercel/analytics"]).toBeDefined();
     expect(pkg.dependencies["@vercel/speed-insights"]).toBeDefined();
 
-    const root = readFileSync(resolve(rootDir, "src/routes/__root.tsx"), "utf8");
+    const root = readFileSync(
+      resolve(rootDir, "src/routes/__root.tsx"),
+      "utf8",
+    );
     expect(root).toContain("VercelAnalytics");
   });
 

--- a/tests/unit/deployment-config.test.ts
+++ b/tests/unit/deployment-config.test.ts
@@ -56,11 +56,12 @@ describe("deployment config", () => {
     }
   });
 
-  it("includes Vercel Web Analytics in the document shell", () => {
+  it("includes Vercel Web Analytics and Speed Insights in the document shell", () => {
     const pkg = readJson("package.json") as {
       dependencies: Record<string, string>;
     };
     expect(pkg.dependencies["@vercel/analytics"]).toBeDefined();
+    expect(pkg.dependencies["@vercel/speed-insights"]).toBeDefined();
 
     const root = readFileSync(resolve(rootDir, "src/routes/__root.tsx"), "utf8");
     expect(root).toContain("VercelAnalytics");

--- a/tests/unit/deployment-config.test.ts
+++ b/tests/unit/deployment-config.test.ts
@@ -56,6 +56,16 @@ describe("deployment config", () => {
     }
   });
 
+  it("includes Vercel Web Analytics in the document shell", () => {
+    const pkg = readJson("package.json") as {
+      dependencies: Record<string, string>;
+    };
+    expect(pkg.dependencies["@vercel/analytics"]).toBeDefined();
+
+    const root = readFileSync(resolve(rootDir, "src/routes/__root.tsx"), "utf8");
+    expect(root).toContain("VercelAnalytics");
+  });
+
   it("uses patched nitro and uuid versions for known GHSA advisories", () => {
     const pkg = readJson("package.json") as {
       devDependencies: {nitro: string};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds Vercel Web Analytics and Speed Insights so page views and Core Web Vitals are collected after deploy.

Both packages mount in the TanStack Start document shell. Client navigations pass a grouped route so proposal pages report as `/proposal/[proposalId]` instead of one row per id.

After merge, enable **Web Analytics** and **Speed Insights** on the Vercel project. The `/_vercel/insights/*` and `/_vercel/speed-insights/*` routes are created on the next deploy after that.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb828da6-7b79-4ff4-8b94-4af3f78d06f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb828da6-7b79-4ff4-8b94-4af3f78d06f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

