### PR TITLE
Publish agent discovery: sitemap, robots signals, catalogs, and markdown

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,7 @@ VITE_APTOS_API_KEY=
 # Aptos Labs URLs — you do not need a geomi.dev host.
 APTOS_FULLNODE_URL=
 APTOS_INDEXER_URL=https://api.mainnet.aptoslabs.com/v1/graphql
+
+# Optional public origin for sitemap, robots.txt, and agent discovery
+# documents. Defaults to the incoming request (x-forwarded-host on Vercel).
+SITE_ORIGIN=https://governance.aptosfoundation.org

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ If any fail, report exact failure and do not claim success.
   into the browser bundle. Do not put a server key (`aptoslabs_…`) there.
 - Current supported vars are listed in `.env.example`.
 - Production hosting is Vercel; set the same vars in the Vercel project.
+- `SITE_ORIGIN` is the optional canonical origin for sitemap/robots/discovery
+  URLs. Leave unset to use the request's forwarded host.
 
 ## Code Editing Guidance
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ SSR: a browser client key (`AG-…`) sent from Node has no `Origin` header.
 - `APTOS_FULLNODE_URL` (optional): fullnode override; defaults to hosted mainnet
 - `APTOS_INDEXER_URL` (optional): indexer override; defaults to
   `https://api.mainnet.aptoslabs.com/v1/graphql`
+- `SITE_ORIGIN` (optional): canonical origin used in `/sitemap.xml`,
+  `/robots.txt`, and `/.well-known/*` discovery documents. Defaults to
+  the request's forwarded host. Production:
+  `https://governance.aptosfoundation.org`
 
 Geomi keys authenticate against those Aptos Labs hosts. Do not point
 `APTOS_FULLNODE_URL` / `APTOS_INDEXER_URL` at `api.geomi.dev`.
@@ -91,6 +95,23 @@ Start server functions, so it cannot be deployed to a static host.
 `vercel.json` pins the framework preset to `tanstack-start` and the pnpm
 install/build commands so the settings do not depend on dashboard state. Set
 the variables above in the Vercel project's environment variable settings.
+
+## Agent discovery
+
+The app publishes machine-readable discovery for AI agents:
+
+- `/sitemap.xml` and `/robots.txt` (Content-Signal + Sitemap)
+- `Link` headers on `/` (`api-catalog`, `service-desc`, `service-doc`)
+- `/.well-known/api-catalog`, `/.well-known/ai-catalog.json`
+- `/.well-known/mcp/server-card.json` and Streamable HTTP `/mcp`
+- `/.well-known/agent-skills/index.json`
+- `/auth.md`, `/.well-known/oauth-protected-resource`,
+  `/.well-known/oauth-authorization-server`
+- `Accept: text/markdown` on HTML pages
+- WebMCP tools registered in the browser on page load
+
+DNS-AID `SVCB` records cannot be served by the app. Operators must publish
+the zone file in `dns/agents.zone` — see `docs/dns-aid.md`.
 
 ## Quality Gates
 

--- a/dns/agents.zone
+++ b/dns/agents.zone
@@ -1,0 +1,12 @@
+; DNS for AI Discovery (DNS-AID) — operator-published records
+; Scanner: DoH against _index._agents.<apex> and _a2a._agents.<apex>
+; Sign this zone with DNSSEC. Grey-cloud / DNS-only (do not HTTP-proxy the names).
+;
+; Replace governance.aptosfoundation.org if this deployment uses another apex.
+
+$TTL 3600
+
+_index._agents.governance.aptosfoundation.org.  3600 IN SVCB 1 governance.aptosfoundation.org. alpn="h2,http/1.1" port=443
+_a2a._agents.governance.aptosfoundation.org.    3600 IN SVCB 1 governance.aptosfoundation.org. alpn="h2,http/1.1" port=443
+_mcp._agents.governance.aptosfoundation.org.    3600 IN HTTPS 1 governance.aptosfoundation.org. alpn="h2,http/1.1" port=443
+_catalog._agents.governance.aptosfoundation.org. 3600 IN TXT "url=https://governance.aptosfoundation.org/.well-known/ai-catalog.json"

--- a/docs/dns-aid.md
+++ b/docs/dns-aid.md
@@ -1,0 +1,50 @@
+# DNS for AI Discovery (DNS-AID)
+
+The [isitagentready.com](https://isitagentready.com) scanner looks up
+DNS-AID records over DNS-over-HTTPS. Those records **cannot be published
+from this web app** — they live in the DNS zone for
+`governance.aptosfoundation.org` (or whichever apex hosts a deployment).
+
+## Records to publish
+
+Copy from [`dns/agents.zone`](../dns/agents.zone). Required shape:
+
+- ServiceMode `SVCB` (priority `1`, not alias-mode `0`) at
+  `_index._agents.<apex>` and `_a2a._agents.<apex>`
+- `alpn` and `port=443` parameters
+- DNSSEC signatures on the public discovery names
+
+Example:
+
+```dns
+_index._agents.governance.aptosfoundation.org.  3600 IN SVCB 1 governance.aptosfoundation.org. alpn="h2,http/1.1" port=443
+_a2a._agents.governance.aptosfoundation.org.    3600 IN SVCB 1 governance.aptosfoundation.org. alpn="h2,http/1.1" port=443
+```
+
+Also recommended:
+
+```dns
+_catalog._agents.governance.aptosfoundation.org. 3600 IN TXT "url=https://governance.aptosfoundation.org/.well-known/ai-catalog.json"
+```
+
+Keep these names **DNS-only** (grey-cloud). An HTTP proxy on the `_agents`
+labels will hide the SVCB answers.
+
+## Check
+
+```bash
+curl -sS 'https://cloudflare-dns.com/dns-query?name=_index._agents.governance.aptosfoundation.org&type=SVCB' \
+  -H 'accept: application/dns-json'
+```
+
+Then:
+
+```http
+POST https://isitagentready.com/api/scan
+Content-Type: application/json
+
+{"url": "https://governance.aptosfoundation.org"}
+```
+
+Expect `checks.discoverability.dnsAid.status` to be `"pass"` once the
+records are live and the zone is signed.

--- a/public/.well-known/agent-skills/get-proposal/SKILL.md
+++ b/public/.well-known/agent-skills/get-proposal/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: get-proposal
+description: Fetch one Aptos governance proposal by numeric id, including description and vote breakdown.
+---
+
+# Get an Aptos governance proposal
+
+Use this skill when the user names a proposal id or wants details for a single AIP.
+
+## HTTP
+
+`GET /api/proposals/{proposalId}`
+
+Votes page: `GET /api/proposals/{proposalId}/votes?page=0`
+
+Human page: `/proposal/{proposalId}`
+
+## MCP
+
+Call tool `get_proposal` with `{ "proposalId": "<id>" }`.

--- a/public/.well-known/agent-skills/list-proposals/SKILL.md
+++ b/public/.well-known/agent-skills/list-proposals/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: list-proposals
+description: List on-chain Aptos Improvement Proposals (AIPs) with status, tallies, and pagination.
+---
+
+# List Aptos governance proposals
+
+Use this skill when the user wants a catalog of current or historical Aptos on-chain proposals.
+
+## HTTP
+
+`GET /api/proposals?page=0`
+
+Response fields include `proposalId`, `status` (`active` | `passed` | `executed` | `failed`), `yesVotes`, `noVotes`, and verified off-chain metadata when the on-chain hash matches.
+
+## MCP
+
+Call tool `list_proposals` on the Streamable HTTP MCP server at `/mcp`.
+
+## WebMCP
+
+On the governance homepage, the browser tool `list_proposals` returns the same JSON.

--- a/public/.well-known/agent-skills/vote-on-proposal/SKILL.md
+++ b/public/.well-known/agent-skills/vote-on-proposal/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: vote-on-proposal
+description: Cast an on-chain Aptos governance vote through a connected wallet. Agents cannot vote without a user wallet signature.
+---
+
+# Vote on an Aptos governance proposal
+
+Voting is an on-chain transaction against `0x1::aptos_governance`. This app never holds private keys.
+
+## Agent flow
+
+1. Open `/proposal/{proposalId}` in the user's browser.
+2. Ask the user to connect an AIP-62 wallet (Petra or any registered wallet).
+3. Use the on-page voting panel. The user must review and sign the transaction.
+4. Do not attempt to submit a vote through the REST or MCP APIs — they are read-only.
+
+## Registration
+
+Read `/auth.md` for agent registration. Read APIs do not require a token.

--- a/public/auth.md
+++ b/public/auth.md
@@ -1,0 +1,65 @@
+# auth.md
+
+You are an agent. Aptos Governance supports **agentic registration** for its public read API. Voting stays on-chain through a user's Aptos wallet.
+
+Follow discover → register → (optional claim) → exchange → call API. Do not skip ahead. Do not POST here during a passive scan.
+
+## Audience
+
+- **Resource:** this origin (`/`)
+- **Human app:** `/`
+- **Read API:** `/api/proposals`
+- **MCP:** `/mcp`
+
+Most data is public. A bearer token is optional identification for `proposals:read`. There is no OAuth grant that can cast a governance vote.
+
+## Step 1 — Discover
+
+### 1a. Protected Resource Metadata
+
+`GET /.well-known/oauth-protected-resource`
+
+Fields: `resource`, `authorization_servers`, `scopes_supported` (`proposals:read`), `bearer_methods_supported` (`header`).
+
+### 1b. Authorization Server metadata
+
+`GET /.well-known/oauth-authorization-server`
+
+Also published as OpenID discovery at `/.well-known/openid-configuration`.
+
+Read `issuer`, `token_endpoint`, `jwks_uri`, `grant_types_supported`, and the `agent_auth` block (`skill`, `register_uri`, `identity_types_supported`).
+
+## Step 2 — Pick a method
+
+1. **Anonymous** (recommended for read-only agents): POST `{"type":"anonymous"}` to `register_uri`.
+2. **Identity assertion** if you have an ID-JAG for this audience (`urn:ietf:params:oauth:token-type:id-jag`).
+3. **Verified email** is advertised for claim ceremony completeness; this deployment does not send email. Use anonymous instead.
+
+## Step 3 — Register
+
+`POST /agent/identity`
+
+`Content-Type: application/json`
+
+```json
+{ "type": "anonymous" }
+```
+
+Response includes `identity_assertion`, `claim_token`, and may include an `access_token` already usable as `Authorization: Bearer`.
+
+## Step 4 — Claim (optional)
+
+Anonymous credentials can stay unclaimed. To attach a human later, POST to `/agent/identity/claim` with the `claim_token`. The user completes the ceremony in the browser at `/delegation` by connecting an Aptos wallet.
+
+## Step 5 — Token
+
+`POST /oauth2/token`
+
+- `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=<identity_assertion>`
+- or `grant_type=client_credentials&scope=proposals:read` (no client secret)
+
+## Step 6 — Call the API
+
+Send `Authorization: Bearer <access_token>` if you have one. Omitting the header is allowed for GET `/api/*`.
+
+Revoke: `POST /oauth2/revoke` with `token=<access_token>`.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,0 @@
-User-agent: *
-Allow: /$
-Disallow: /

--- a/src/components/WebMcpTools.tsx
+++ b/src/components/WebMcpTools.tsx
@@ -1,0 +1,123 @@
+import {useEffect} from "react";
+
+type JsonSchema = {
+  type: string;
+  properties?: Record<string, unknown>;
+  required?: string[];
+  additionalProperties?: boolean;
+};
+
+type WebMcpTool = {
+  name: string;
+  description: string;
+  inputSchema: JsonSchema;
+  execute: (input: Record<string, unknown>) => Promise<unknown>;
+};
+
+type ModelContext = {
+  registerTool: (
+    tool: WebMcpTool,
+    options?: {signal?: AbortSignal},
+  ) => Promise<unknown> | unknown;
+  provideContext?: (input: {tools: WebMcpTool[]}) => Promise<unknown> | unknown;
+};
+
+function getModelContext(): ModelContext | undefined {
+  const nav = navigator as Navigator & {modelContext?: ModelContext};
+  const doc = document as Document & {modelContext?: ModelContext};
+  return nav.modelContext ?? doc.modelContext;
+}
+
+async function fetchJson(path: string): Promise<unknown> {
+  const response = await fetch(path);
+  if (!response.ok) {
+    throw new Error(`${path} returned ${response.status}`);
+  }
+  return response.json();
+}
+
+const TOOLS: WebMcpTool[] = [
+  {
+    name: "list_proposals",
+    description:
+      "List on-chain Aptos Improvement Proposals, newest first. Optional 0-based page.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        page: {type: "integer", minimum: 0, default: 0},
+      },
+      additionalProperties: false,
+    },
+    execute: async ({page}) => {
+      const param = typeof page === "number" ? page : 0;
+      return fetchJson(`/api/proposals?page=${param}`);
+    },
+  },
+  {
+    name: "get_proposal",
+    description: "Fetch one Aptos governance proposal by numeric id.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        proposalId: {type: "string", description: "Non-negative integer id"},
+      },
+      required: ["proposalId"],
+      additionalProperties: false,
+    },
+    execute: async ({proposalId}) => {
+      return fetchJson(`/api/proposals/${String(proposalId)}`);
+    },
+  },
+  {
+    name: "open_proposal",
+    description:
+      "Navigate this page to a proposal's human-readable detail view.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        proposalId: {type: "string"},
+      },
+      required: ["proposalId"],
+      additionalProperties: false,
+    },
+    execute: async ({proposalId}) => {
+      const href = `/proposal/${String(proposalId)}`;
+      window.location.assign(href);
+      return {ok: true, href};
+    },
+  },
+];
+
+/**
+ * Registers WebMCP tools on load. Detected by agent scanners that
+ * execute the homepage in a browser (navigator.modelContext / document.modelContext).
+ */
+export function WebMcpTools() {
+  useEffect(() => {
+    const context = getModelContext();
+    if (!context) return;
+    const abort = new AbortController();
+
+    void (async () => {
+      try {
+        if (typeof context.provideContext === "function") {
+          await context.provideContext({tools: TOOLS});
+        }
+      } catch {
+        // Older previews only implement registerTool.
+      }
+      for (const tool of TOOLS) {
+        if (abort.signal.aborted) return;
+        try {
+          await context.registerTool(tool, {signal: abort.signal});
+        } catch {
+          // Browser has no WebMCP — ignore.
+        }
+      }
+    })();
+
+    return () => abort.abort();
+  }, []);
+
+  return null;
+}

--- a/src/lib/agent-discovery/api-catalog.ts
+++ b/src/lib/agent-discovery/api-catalog.ts
@@ -1,0 +1,53 @@
+import {absoluteUrl} from "~/lib/agent-discovery/origin";
+
+export function buildApiCatalog(origin: string) {
+  return {
+    linkset: [
+      {
+        anchor: absoluteUrl(origin, "/api/proposals"),
+        "service-desc": [
+          {
+            href: absoluteUrl(origin, "/openapi.json"),
+            type: "application/json",
+          },
+        ],
+        "service-doc": [
+          {
+            href: absoluteUrl(origin, "/docs/api"),
+            type: "text/markdown",
+          },
+        ],
+        status: [
+          {
+            href: absoluteUrl(origin, "/api/health"),
+            type: "application/json",
+          },
+        ],
+      },
+      {
+        anchor: absoluteUrl(origin, "/mcp"),
+        "service-desc": [
+          {
+            href: absoluteUrl(origin, "/.well-known/mcp/server-card.json"),
+            type: "application/json",
+          },
+        ],
+        "service-doc": [
+          {
+            href: absoluteUrl(origin, "/docs/api"),
+            type: "text/markdown",
+          },
+        ],
+        status: [
+          {
+            href: absoluteUrl(origin, "/api/health"),
+            type: "application/json",
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export const API_CATALOG_CONTENT_TYPE =
+  'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"';

--- a/src/lib/agent-discovery/ard.ts
+++ b/src/lib/agent-discovery/ard.ts
@@ -1,0 +1,60 @@
+import {absoluteUrl} from "~/lib/agent-discovery/origin";
+
+const HOST = "governance.aptosfoundation.org";
+
+export function buildArdCatalog(origin: string) {
+  return {
+    specVersion: "1.0",
+    host: {
+      displayName: "Aptos Governance",
+      identifier: `did:web:${HOST}`,
+    },
+    entries: [
+      {
+        identifier: `urn:air:${HOST}:server:mcp`,
+        displayName: "Aptos Governance MCP server",
+        type: "application/mcp-server-card+json",
+        url: absoluteUrl(origin, "/.well-known/mcp/server-card.json"),
+        representativeQueries: [
+          "list open Aptos improvement proposals",
+          "get the current yes and no votes for a proposal",
+          "what is the status of Aptos governance proposal 80",
+        ],
+      },
+      {
+        identifier: `urn:air:${HOST}:api:proposals`,
+        displayName: "Aptos Governance REST API",
+        type: "application/vnd.oai.openapi+json",
+        url: absoluteUrl(origin, "/openapi.json"),
+        representativeQueries: [
+          "fetch the latest on-chain Aptos proposals as JSON",
+          "look up a governance proposal by numeric id",
+          "check whether the governance API is healthy",
+        ],
+      },
+      {
+        identifier: `urn:air:${HOST}:skill:list-proposals`,
+        displayName: "List Aptos governance proposals skill",
+        type: "text/markdown",
+        url: absoluteUrl(
+          origin,
+          "/.well-known/agent-skills/list-proposals/SKILL.md",
+        ),
+        representativeQueries: [
+          "how do I list Aptos governance proposals as an agent",
+          "what HTTP API returns current AIPs",
+        ],
+      },
+      {
+        identifier: `urn:air:${HOST}:docs:auth`,
+        displayName: "Agent registration (auth.md)",
+        type: "text/markdown",
+        url: absoluteUrl(origin, "/auth.md"),
+        representativeQueries: [
+          "how do agents authenticate to Aptos Governance",
+          "register an agent for the governance API",
+        ],
+      },
+    ],
+  };
+}

--- a/src/lib/agent-discovery/dispatch.ts
+++ b/src/lib/agent-discovery/dispatch.ts
@@ -1,0 +1,336 @@
+import {
+  API_CATALOG_CONTENT_TYPE,
+  buildApiCatalog,
+} from "~/lib/agent-discovery/api-catalog";
+import {buildArdCatalog} from "~/lib/agent-discovery/ard";
+import {homepageLinkHeaderValue} from "~/lib/agent-discovery/headers";
+import {
+  asHead,
+  emptyResponse,
+  jsonResponse,
+  methodNotAllowed,
+  notFound,
+  textResponse,
+  wantsMarkdown,
+} from "~/lib/agent-discovery/http";
+import {markdownResponse} from "~/lib/agent-discovery/markdown";
+import {handleMcp} from "~/lib/agent-discovery/mcp";
+import {buildMcpJson, buildMcpServerCard} from "~/lib/agent-discovery/mcp-card";
+import {
+  buildAuthMd,
+  buildAuthorizationServerMetadata,
+  buildAuthorizeHtml,
+  buildJwks,
+  buildOpenIdConfiguration,
+  buildProtectedResourceMetadata,
+} from "~/lib/agent-discovery/oauth";
+import {
+  handleClaim,
+  handleEventNotify,
+  handleIdentity,
+  handleRevoke,
+  handleToken,
+  handleUserinfo,
+} from "~/lib/agent-discovery/oauth-handlers";
+import {
+  buildApiDocsHtml,
+  buildApiDocsMarkdown,
+  buildOpenApiDocument,
+} from "~/lib/agent-discovery/openapi";
+import {publicOrigin} from "~/lib/agent-discovery/origin";
+import {
+  handleGetProposal,
+  handleHealth,
+  handleListProposals,
+  handleListVotes,
+} from "~/lib/agent-discovery/rest";
+import {buildRobotsTxt} from "~/lib/agent-discovery/robots";
+import {buildSitemapXml} from "~/lib/agent-discovery/sitemap";
+import {
+  buildSkillsIndex,
+  findSkill,
+  skillMarkdown,
+} from "~/lib/agent-discovery/skills";
+
+const GET_HEAD = new Set(["GET", "HEAD"]);
+const GET_HEAD_POST = new Set(["GET", "HEAD", "POST"]);
+const GET_HEAD_POST_OPTIONS = new Set(["GET", "HEAD", "POST", "OPTIONS"]);
+
+function maybeHead(request: Request, response: Response): Response {
+  return request.method === "HEAD" ? asHead(response) : response;
+}
+
+function allow(
+  request: Request,
+  methods: Set<string>,
+  allowHeader: string,
+): Response | null {
+  if (request.method === "OPTIONS") {
+    return emptyResponse(204, {Allow: allowHeader});
+  }
+  if (!methods.has(request.method)) {
+    return methodNotAllowed(allowHeader);
+  }
+  return null;
+}
+
+export function isAgentDiscoveryPath(pathname: string): boolean {
+  if (
+    pathname === "/sitemap.xml" ||
+    pathname === "/robots.txt" ||
+    pathname === "/auth.md" ||
+    pathname === "/openapi.json" ||
+    pathname === "/docs/api" ||
+    pathname === "/mcp" ||
+    pathname === "/oauth2/authorize" ||
+    pathname === "/oauth2/token" ||
+    pathname === "/oauth2/revoke" ||
+    pathname === "/oauth2/userinfo" ||
+    pathname === "/agent/identity" ||
+    pathname === "/agent/identity/claim" ||
+    pathname === "/agent/event/notify"
+  ) {
+    return true;
+  }
+  if (pathname.startsWith("/.well-known/")) return true;
+  if (pathname === "/api/health" || pathname === "/api/proposals") return true;
+  if (/^\/api\/proposals\/[^/]+(?:\/votes)?$/.test(pathname)) return true;
+  return false;
+}
+
+export async function handleAgentDiscoveryRequest(
+  request: Request,
+): Promise<Response | null> {
+  const path = new URL(request.url).pathname.replace(/\/+$/, "") || "/";
+  if (!isAgentDiscoveryPath(path)) return null;
+
+  const origin = publicOrigin(request);
+
+  if (path === "/robots.txt") {
+    const blocked = allow(request, GET_HEAD, "GET, HEAD, OPTIONS");
+    if (blocked) return blocked;
+    return maybeHead(
+      request,
+      textResponse(buildRobotsTxt(origin), "text/plain; charset=utf-8"),
+    );
+  }
+
+  if (path === "/sitemap.xml") {
+    const blocked = allow(request, GET_HEAD, "GET, HEAD, OPTIONS");
+    if (blocked) return blocked;
+    const xml = await buildSitemapXml(origin);
+    return maybeHead(
+      request,
+      textResponse(xml, "application/xml; charset=utf-8"),
+    );
+  }
+
+  if (path === "/auth.md") {
+    const blocked = allow(request, GET_HEAD, "GET, HEAD, OPTIONS");
+    if (blocked) return blocked;
+    return maybeHead(request, markdownResponse(buildAuthMd(origin)));
+  }
+
+  if (path === "/openapi.json") {
+    const blocked = allow(request, GET_HEAD, "GET, HEAD, OPTIONS");
+    if (blocked) return blocked;
+    return maybeHead(request, jsonResponse(buildOpenApiDocument(origin)));
+  }
+
+  if (path === "/docs/api") {
+    const blocked = allow(request, GET_HEAD, "GET, HEAD, OPTIONS");
+    if (blocked) return blocked;
+    if (wantsMarkdown(request)) {
+      return maybeHead(request, markdownResponse(buildApiDocsMarkdown(origin)));
+    }
+    return maybeHead(
+      request,
+      textResponse(buildApiDocsHtml(origin), "text/html; charset=utf-8"),
+    );
+  }
+
+  if (path === "/api/health") {
+    const blocked = allow(request, GET_HEAD, "GET, HEAD, OPTIONS");
+    if (blocked) return blocked;
+    return maybeHead(request, handleHealth(request));
+  }
+
+  if (path === "/api/proposals") {
+    const blocked = allow(request, GET_HEAD, "GET, HEAD, OPTIONS");
+    if (blocked) return blocked;
+    return maybeHead(request, await handleListProposals(request));
+  }
+
+  const proposalVotes = path.match(/^\/api\/proposals\/([^/]+)\/votes$/);
+  if (proposalVotes) {
+    const blocked = allow(request, GET_HEAD, "GET, HEAD, OPTIONS");
+    if (blocked) return blocked;
+    return maybeHead(
+      request,
+      await handleListVotes(request, proposalVotes[1]!),
+    );
+  }
+
+  const proposal = path.match(/^\/api\/proposals\/([^/]+)$/);
+  if (proposal) {
+    const blocked = allow(request, GET_HEAD, "GET, HEAD, OPTIONS");
+    if (blocked) return blocked;
+    return maybeHead(request, await handleGetProposal(request, proposal[1]!));
+  }
+
+  if (path === "/mcp") {
+    const blocked = allow(request, GET_HEAD_POST, "GET, HEAD, POST, OPTIONS");
+    if (blocked) return blocked;
+    return maybeHead(request, await handleMcp(request));
+  }
+
+  if (path === "/oauth2/authorize") {
+    const blocked = allow(request, GET_HEAD, "GET, HEAD, OPTIONS");
+    if (blocked) return blocked;
+    return maybeHead(
+      request,
+      textResponse(buildAuthorizeHtml(origin), "text/html; charset=utf-8"),
+    );
+  }
+
+  if (path === "/oauth2/token") {
+    const blocked = allow(
+      request,
+      new Set(["POST", "OPTIONS"]),
+      "POST, OPTIONS",
+    );
+    if (blocked) return blocked;
+    return handleToken(request);
+  }
+
+  if (path === "/oauth2/revoke") {
+    const blocked = allow(
+      request,
+      new Set(["POST", "OPTIONS"]),
+      "POST, OPTIONS",
+    );
+    if (blocked) return blocked;
+    return handleRevoke(request);
+  }
+
+  if (path === "/oauth2/userinfo") {
+    const blocked = allow(request, GET_HEAD, "GET, HEAD, OPTIONS");
+    if (blocked) return blocked;
+    return maybeHead(request, handleUserinfo());
+  }
+
+  if (path === "/agent/identity") {
+    const blocked = allow(request, GET_HEAD_POST, "GET, HEAD, POST, OPTIONS");
+    if (blocked) return blocked;
+    return maybeHead(request, await handleIdentity(request));
+  }
+
+  if (path === "/agent/identity/claim") {
+    const blocked = allow(
+      request,
+      GET_HEAD_POST_OPTIONS,
+      "GET, HEAD, POST, OPTIONS",
+    );
+    if (blocked) return blocked;
+    return maybeHead(request, await handleClaim(request));
+  }
+
+  if (path === "/agent/event/notify") {
+    const blocked = allow(
+      request,
+      new Set(["POST", "OPTIONS"]),
+      "POST, OPTIONS",
+    );
+    if (blocked) return blocked;
+    return handleEventNotify();
+  }
+
+  if (path === "/.well-known/api-catalog") {
+    const blocked = allow(request, GET_HEAD, "GET, HEAD, OPTIONS");
+    if (blocked) return blocked;
+    const headers = {
+      Link: `</.well-known/api-catalog>; rel="api-catalog", ${homepageLinkHeaderValue()}`,
+    };
+    return maybeHead(
+      request,
+      jsonResponse(buildApiCatalog(origin), API_CATALOG_CONTENT_TYPE, headers),
+    );
+  }
+
+  if (path === "/.well-known/ai-catalog.json") {
+    const blocked = allow(request, GET_HEAD, "GET, HEAD, OPTIONS");
+    if (blocked) return blocked;
+    return maybeHead(
+      request,
+      jsonResponse(buildArdCatalog(origin), "application/json; charset=utf-8", {
+        "Access-Control-Allow-Origin": "*",
+      }),
+    );
+  }
+
+  if (path === "/.well-known/oauth-protected-resource") {
+    const blocked = allow(request, GET_HEAD, "GET, HEAD, OPTIONS");
+    if (blocked) return blocked;
+    return maybeHead(
+      request,
+      jsonResponse(buildProtectedResourceMetadata(origin)),
+    );
+  }
+
+  if (path === "/.well-known/oauth-authorization-server") {
+    const blocked = allow(request, GET_HEAD, "GET, HEAD, OPTIONS");
+    if (blocked) return blocked;
+    return maybeHead(
+      request,
+      jsonResponse(buildAuthorizationServerMetadata(origin)),
+    );
+  }
+
+  if (path === "/.well-known/openid-configuration") {
+    const blocked = allow(request, GET_HEAD, "GET, HEAD, OPTIONS");
+    if (blocked) return blocked;
+    return maybeHead(request, jsonResponse(buildOpenIdConfiguration(origin)));
+  }
+
+  if (path === "/.well-known/jwks.json") {
+    const blocked = allow(request, GET_HEAD, "GET, HEAD, OPTIONS");
+    if (blocked) return blocked;
+    return maybeHead(request, jsonResponse(buildJwks()));
+  }
+
+  if (
+    path === "/.well-known/mcp/server-card.json" ||
+    path === "/.well-known/mcp.json"
+  ) {
+    const blocked = allow(request, GET_HEAD, "GET, HEAD, OPTIONS");
+    if (blocked) return blocked;
+    const body =
+      path === "/.well-known/mcp.json"
+        ? buildMcpJson(origin)
+        : buildMcpServerCard(origin);
+    return maybeHead(request, jsonResponse(body));
+  }
+
+  if (path === "/.well-known/agent-skills/index.json") {
+    const blocked = allow(request, GET_HEAD, "GET, HEAD, OPTIONS");
+    if (blocked) return blocked;
+    return maybeHead(request, jsonResponse(buildSkillsIndex(origin)));
+  }
+
+  const skillMatch = path.match(
+    /^\/\.well-known\/agent-skills\/([^/]+)\/SKILL\.md$/,
+  );
+  if (skillMatch) {
+    const blocked = allow(request, GET_HEAD, "GET, HEAD, OPTIONS");
+    if (blocked) return blocked;
+    const skill = findSkill(skillMatch[1]!);
+    if (!skill) return notFound("Unknown skill");
+    return maybeHead(request, markdownResponse(skillMarkdown(skill, origin)));
+  }
+
+  if (path.startsWith("/.well-known/")) {
+    return notFound(`No well-known resource at ${path}`);
+  }
+
+  return notFound();
+}

--- a/src/lib/agent-discovery/headers.ts
+++ b/src/lib/agent-discovery/headers.ts
@@ -1,0 +1,39 @@
+import {absoluteUrl} from "~/lib/agent-discovery/origin";
+
+export function discoveryLinkHeader(origin: string): string {
+  const catalog = absoluteUrl(origin, "/.well-known/api-catalog");
+  const openapi = absoluteUrl(origin, "/openapi.json");
+  const docs = absoluteUrl(origin, "/docs/api");
+  const ard = absoluteUrl(origin, "/.well-known/ai-catalog.json");
+  return [
+    `<${catalog}>; rel="api-catalog"`,
+    `<${openapi}>; rel="service-desc"; type="application/json"`,
+    `<${docs}>; rel="service-doc"; type="text/markdown"`,
+    `<${ard}>; rel="describedby"; type="application/json"`,
+  ].join(", ");
+}
+
+export function homepageLinkHeaderValue(): string {
+  return [
+    '</.well-known/api-catalog>; rel="api-catalog"',
+    '</openapi.json>; rel="service-desc"; type="application/json"',
+    '</docs/api>; rel="service-doc"; type="text/markdown"',
+    '</.well-known/ai-catalog.json>; rel="describedby"; type="application/json"',
+  ].join(", ");
+}
+
+export function isHomepagePath(pathname: string): boolean {
+  return pathname === "/" || pathname === "";
+}
+
+export function withLinkHeader(response: Response, pathname: string): Response {
+  if (!isHomepagePath(pathname)) return response;
+  if (response.headers.has("Link")) return response;
+  const headers = new Headers(response.headers);
+  headers.append("Link", homepageLinkHeaderValue());
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/src/lib/agent-discovery/http.ts
+++ b/src/lib/agent-discovery/http.ts
@@ -1,0 +1,109 @@
+export const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, HEAD, POST, OPTIONS",
+  "Access-Control-Allow-Headers":
+    "Accept, Authorization, Content-Type, MCP-Protocol-Version",
+  "Access-Control-Expose-Headers": "Link, x-markdown-tokens, WWW-Authenticate",
+} as const;
+
+export const DISCOVERY_CACHE_CONTROL = "public, max-age=300";
+
+export function textResponse(
+  body: string,
+  contentType: string,
+  extraHeaders: Record<string, string> = {},
+  status = 200,
+): Response {
+  const headers = new Headers({
+    "Content-Type": contentType,
+    "Cache-Control": DISCOVERY_CACHE_CONTROL,
+    ...CORS_HEADERS,
+    ...extraHeaders,
+  });
+  return new Response(body, {status, headers});
+}
+
+export function jsonResponse(
+  body: unknown,
+  contentType = "application/json; charset=utf-8",
+  extraHeaders: Record<string, string> = {},
+  status = 200,
+): Response {
+  return textResponse(
+    `${JSON.stringify(body, null, 2)}\n`,
+    contentType,
+    extraHeaders,
+    status,
+  );
+}
+
+export function emptyResponse(
+  status: number,
+  extraHeaders: Record<string, string> = {},
+): Response {
+  return new Response(null, {
+    status,
+    headers: {
+      "Cache-Control": DISCOVERY_CACHE_CONTROL,
+      ...CORS_HEADERS,
+      ...extraHeaders,
+    },
+  });
+}
+
+export function methodNotAllowed(allow: string): Response {
+  return textResponse(
+    "Method not allowed\n",
+    "text/plain; charset=utf-8",
+    {
+      Allow: allow,
+    },
+    405,
+  );
+}
+
+export function notFound(message = "Not found"): Response {
+  return jsonResponse(
+    {error: message},
+    "application/json; charset=utf-8",
+    {},
+    404,
+  );
+}
+
+export function asHead(response: Response): Response {
+  return new Response(null, {
+    status: response.status,
+    headers: response.headers,
+  });
+}
+
+export function wantsMarkdown(request: Request): boolean {
+  const accept = request.headers.get("accept") ?? "";
+  if (!accept) return false;
+  const markdown = qValue(accept, "text/markdown");
+  if (markdown <= 0) return false;
+  const html = qValue(accept, "text/html");
+  const json = qValue(accept, "application/json");
+  const any = qValue(accept, "*/*");
+  // Prefer markdown when it is explicitly listed and not outranked.
+  const bestAlternative = Math.max(html, json, any > 0 && html === 0 ? 0 : any);
+  return markdown >= bestAlternative;
+}
+
+function qValue(accept: string, type: string): number {
+  const parts = accept.split(",").map((part) => part.trim());
+  for (const part of parts) {
+    const [rawType, ...params] = part.split(";").map((item) => item.trim());
+    if (!rawType) continue;
+    const matches =
+      rawType === type ||
+      (rawType.endsWith("/*") && type.startsWith(rawType.slice(0, -1)));
+    if (!matches) continue;
+    const qParam = params.find((param) => param.startsWith("q="));
+    const q = qParam ? Number.parseFloat(qParam.slice(2)) : 1;
+    if (Number.isFinite(q)) return q;
+    return 1;
+  }
+  return 0;
+}

--- a/src/lib/agent-discovery/markdown.ts
+++ b/src/lib/agent-discovery/markdown.ts
@@ -1,0 +1,120 @@
+function stripSection(html: string, tag: string): string {
+  const pattern = new RegExp(`<${tag}[^>]*>[\\s\\S]*?<\\/${tag}>`, "gi");
+  return html.replace(pattern, " ");
+}
+
+function decodeEntities(value: string): string {
+  return value
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'");
+}
+
+function collapseBlankLines(value: string): string {
+  return value
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function convertInline(html: string): string {
+  return decodeEntities(
+    html
+      .replace(
+        /<a\b[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi,
+        (_, href, text) => {
+          const label = convertInline(text).replace(/\s+/g, " ").trim();
+          return label ? `[${label}](${href})` : href;
+        },
+      )
+      .replace(/<\/?(strong|b)>/gi, "**")
+      .replace(/<\/?(em|i)>/gi, "_")
+      .replace(
+        /<code[^>]*>([\s\S]*?)<\/code>/gi,
+        (_, code) => `\`${decodeEntities(code)}\``,
+      )
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<[^>]+>/g, ""),
+  );
+}
+
+/**
+ * Lightweight HTML → Markdown for agent Accept: text/markdown.
+ * Prefers <main> when present and strips scripts/styles/chrome noise.
+ */
+export function htmlToMarkdown(html: string): string {
+  let source = html;
+  const mainMatch = html.match(/<main\b[^>]*>([\s\S]*?)<\/main>/i);
+  if (mainMatch?.[1]) {
+    const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+    const title = titleMatch ? convertInline(titleMatch[1]).trim() : "";
+    source = title ? `<h1>${title}</h1>${mainMatch[1]}` : mainMatch[1];
+  }
+
+  source = stripSection(source, "script");
+  source = stripSection(source, "style");
+  source = stripSection(source, "noscript");
+  source = stripSection(source, "svg");
+
+  source = source.replace(
+    /<h([1-6])[^>]*>([\s\S]*?)<\/h\1>/gi,
+    (_, level, inner) => {
+      const hashes = "#".repeat(Number(level));
+      return `\n\n${hashes} ${convertInline(inner).trim()}\n\n`;
+    },
+  );
+  source = source.replace(/<p[^>]*>([\s\S]*?)<\/p>/gi, (_, inner) => {
+    return `\n\n${convertInline(inner).trim()}\n\n`;
+  });
+  source = source.replace(/<li[^>]*>([\s\S]*?)<\/li>/gi, (_, inner) => {
+    return `\n- ${convertInline(inner).trim()}`;
+  });
+  source = source.replace(/<\/?(ul|ol)[^>]*>/gi, "\n");
+  source = source.replace(/<pre[^>]*>([\s\S]*?)<\/pre>/gi, (_, inner) => {
+    return `\n\n\`\`\`\n${decodeEntities(inner.replace(/<[^>]+>/g, "")).trim()}\n\`\`\`\n\n`;
+  });
+  source = source.replace(/<[^>]+>/g, " ");
+  return collapseBlankLines(decodeEntities(source));
+}
+
+export function countMarkdownTokens(markdown: string): number {
+  const tokens = markdown.trim().split(/\s+/).filter(Boolean);
+  return tokens.length;
+}
+
+export async function markdownFromHtmlResponse(
+  htmlResponse: Response,
+): Promise<Response | null> {
+  const contentType = htmlResponse.headers.get("content-type") ?? "";
+  if (!contentType.includes("text/html")) return null;
+  const html = await htmlResponse.text();
+  const markdown = htmlToMarkdown(html);
+  const tokens = countMarkdownTokens(markdown);
+  const headers = new Headers(htmlResponse.headers);
+  headers.set("Content-Type", "text/markdown; charset=utf-8");
+  headers.set("x-markdown-tokens", String(tokens));
+  headers.delete("content-length");
+  return new Response(markdown, {
+    status: htmlResponse.status,
+    statusText: htmlResponse.statusText,
+    headers,
+  });
+}
+
+export function markdownResponse(
+  markdown: string,
+  extraHeaders: Record<string, string> = {},
+): Response {
+  const tokens = countMarkdownTokens(markdown);
+  const headers = new Headers({
+    "Content-Type": "text/markdown; charset=utf-8",
+    "x-markdown-tokens": String(tokens),
+    "Access-Control-Allow-Origin": "*",
+    "Cache-Control": "public, max-age=300",
+    ...extraHeaders,
+  });
+  return new Response(markdown, {headers});
+}

--- a/src/lib/agent-discovery/mcp-card.ts
+++ b/src/lib/agent-discovery/mcp-card.ts
@@ -1,0 +1,55 @@
+import {absoluteUrl} from "~/lib/agent-discovery/origin";
+
+export const APP_VERSION = "1.0.0";
+
+export function buildMcpServerCard(origin: string) {
+  return {
+    $schema:
+      "https://static.modelcontextprotocol.io/schemas/mcp-server-card/v1.json",
+    version: "1.0",
+    protocolVersion: "2025-06-18",
+    serverInfo: {
+      name: "aptos-governance",
+      title: "Aptos Governance",
+      version: APP_VERSION,
+      description:
+        "Read on-chain Aptos Improvement Proposals, vote tallies, and voter breakdowns.",
+      homepage: origin,
+    },
+    transport: {
+      type: "streamable-http",
+      endpoint: "/mcp",
+    },
+    capabilities: {
+      tools: {listChanged: false},
+      resources: {subscribe: false, listChanged: false},
+      prompts: {listChanged: false},
+    },
+    authentication: {
+      required: false,
+      schemes: [],
+    },
+    instructions:
+      "Use list_proposals to browse AIPs and get_proposal for a single proposal id. Voting is on-chain via an Aptos wallet, not this MCP server.",
+    tools: "dynamic",
+    resources: "dynamic",
+    prompts: "dynamic",
+  };
+}
+
+export function buildMcpJson(origin: string) {
+  return {
+    $schema:
+      "https://static.modelcontextprotocol.io/schemas/mcp-server-card/v1.json",
+    name: "aptos-governance",
+    description:
+      "Read on-chain Aptos Improvement Proposals, vote tallies, and voter breakdowns.",
+    version: APP_VERSION,
+    remotes: [
+      {
+        type: "streamable-http",
+        url: absoluteUrl(origin, "/mcp"),
+      },
+    ],
+  };
+}

--- a/src/lib/agent-discovery/mcp.ts
+++ b/src/lib/agent-discovery/mcp.ts
@@ -1,0 +1,153 @@
+import {jsonResponse} from "~/lib/agent-discovery/http";
+import {APP_VERSION} from "~/lib/agent-discovery/mcp-card";
+import {publicOrigin} from "~/lib/agent-discovery/origin";
+import {loadProposalDetail} from "~/lib/governance/fetch-proposal";
+import {loadProposalListPage} from "~/lib/governance/fetch-proposals";
+import {proposalToJson} from "~/lib/governance/json";
+
+interface JsonRpcRequest {
+  jsonrpc?: string;
+  id?: string | number | null;
+  method?: string;
+  params?: unknown;
+}
+
+const TOOLS = [
+  {
+    name: "list_proposals",
+    description:
+      "List on-chain Aptos Improvement Proposals, newest first. Optional page (0-based).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        page: {type: "integer", minimum: 0, default: 0},
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_proposal",
+    description: "Get one Aptos governance proposal by numeric id.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        proposalId: {type: "string", description: "Non-negative integer id"},
+      },
+      required: ["proposalId"],
+      additionalProperties: false,
+    },
+  },
+];
+
+function rpcResult(id: JsonRpcRequest["id"], result: unknown): Response {
+  return jsonResponse({jsonrpc: "2.0", id: id ?? null, result});
+}
+
+function rpcError(
+  id: JsonRpcRequest["id"],
+  code: number,
+  message: string,
+): Response {
+  return jsonResponse({
+    jsonrpc: "2.0",
+    id: id ?? null,
+    error: {code, message},
+  });
+}
+
+function textResult(id: JsonRpcRequest["id"], payload: unknown): Response {
+  return rpcResult(id, {
+    content: [{type: "text", text: JSON.stringify(payload, null, 2)}],
+    structuredContent: payload,
+  });
+}
+
+async function callTool(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  if (name === "list_proposals") {
+    const page = typeof args.page === "number" ? args.page : 0;
+    const result = await loadProposalListPage(page);
+    return {
+      items: result.items.map(proposalToJson),
+      totalCount: result.totalCount,
+      page: result.page,
+      pageSize: result.pageSize,
+    };
+  }
+  if (name === "get_proposal") {
+    const proposalId = String(args.proposalId ?? "");
+    const result = await loadProposalDetail(proposalId, 0);
+    return {proposal: proposalToJson(result.proposal)};
+  }
+  throw new Error(`Unknown tool: ${name}`);
+}
+
+export async function handleMcp(request: Request): Promise<Response> {
+  const origin = publicOrigin(request);
+  if (request.method === "GET" || request.method === "HEAD") {
+    return jsonResponse({
+      protocolVersion: "2025-06-18",
+      serverInfo: {name: "aptos-governance", version: APP_VERSION},
+      transport: "streamable-http",
+      endpoint: `${origin}/mcp`,
+    });
+  }
+
+  let body: JsonRpcRequest;
+  try {
+    body = (await request.json()) as JsonRpcRequest;
+  } catch {
+    return rpcError(null, -32700, "Parse error");
+  }
+
+  const method = body.method ?? "";
+  const id = body.id ?? null;
+
+  if (method === "initialize") {
+    return rpcResult(id, {
+      protocolVersion: "2025-06-18",
+      capabilities: {tools: {}, resources: {}, prompts: {}},
+      serverInfo: {
+        name: "aptos-governance",
+        version: APP_VERSION,
+      },
+      instructions:
+        "Read-only Aptos governance tools. Use list_proposals and get_proposal.",
+    });
+  }
+
+  if (method === "notifications/initialized" || method === "ping") {
+    return rpcResult(id, {});
+  }
+
+  if (method === "tools/list") {
+    return rpcResult(id, {tools: TOOLS});
+  }
+
+  if (method === "resources/list") {
+    return rpcResult(id, {resources: []});
+  }
+
+  if (method === "prompts/list") {
+    return rpcResult(id, {prompts: []});
+  }
+
+  if (method === "tools/call") {
+    const params = (body.params ?? {}) as {
+      name?: string;
+      arguments?: Record<string, unknown>;
+    };
+    const name = params.name ?? "";
+    try {
+      const payload = await callTool(name, params.arguments ?? {});
+      return textResult(id, payload);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Tool failed";
+      return rpcError(id, -32000, message);
+    }
+  }
+
+  return rpcError(id, -32601, `Method not found: ${method}`);
+}

--- a/src/lib/agent-discovery/oauth-handlers.ts
+++ b/src/lib/agent-discovery/oauth-handlers.ts
@@ -1,0 +1,199 @@
+import {randomBytes} from "node:crypto";
+import {jsonResponse} from "~/lib/agent-discovery/http";
+import {READ_SCOPE} from "~/lib/agent-discovery/oauth";
+import {publicOrigin} from "~/lib/agent-discovery/origin";
+
+interface IssuedToken {
+  sub: string;
+  scope: string;
+  expiresAt: number;
+}
+
+const tokens = new Map<string, IssuedToken>();
+const assertions = new Map<string, IssuedToken>();
+
+const TOKEN_TTL_MS = 60 * 60 * 1000;
+
+function prune(now = Date.now()): void {
+  for (const [key, value] of tokens) {
+    if (value.expiresAt <= now) tokens.delete(key);
+  }
+  for (const [key, value] of assertions) {
+    if (value.expiresAt <= now) assertions.delete(key);
+  }
+}
+
+function mintOpaque(): string {
+  return randomBytes(24).toString("base64url");
+}
+
+function issue(
+  sub: string,
+  scope = READ_SCOPE,
+): {
+  accessToken: string;
+  assertion: string;
+  expiresIn: number;
+} {
+  prune();
+  const expiresAt = Date.now() + TOKEN_TTL_MS;
+  const record: IssuedToken = {sub, scope, expiresAt};
+  const accessToken = mintOpaque();
+  const assertion = mintOpaque();
+  tokens.set(accessToken, record);
+  assertions.set(assertion, record);
+  return {
+    accessToken,
+    assertion,
+    expiresIn: Math.floor(TOKEN_TTL_MS / 1000),
+  };
+}
+
+function tokenPayload(
+  origin: string,
+  issued: {accessToken: string; assertion: string; expiresIn: number},
+  extra: Record<string, unknown> = {},
+) {
+  return {
+    access_token: issued.accessToken,
+    token_type: "Bearer",
+    expires_in: issued.expiresIn,
+    scope: READ_SCOPE,
+    identity_assertion: issued.assertion,
+    claim_token: issued.assertion,
+    resource: `${origin}/`,
+    ...extra,
+  };
+}
+
+async function readBody(request: Request): Promise<Record<string, string>> {
+  const contentType = request.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    const json = (await request.json()) as Record<string, unknown>;
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(json)) {
+      if (value === undefined || value === null) continue;
+      out[key] = String(value);
+    }
+    return out;
+  }
+  const text = await request.text();
+  const params = new URLSearchParams(text);
+  const out: Record<string, string> = {};
+  for (const [key, value] of params.entries()) {
+    out[key] = value;
+  }
+  return out;
+}
+
+export async function handleIdentity(request: Request): Promise<Response> {
+  const origin = publicOrigin(request);
+  if (request.method === "GET") {
+    return jsonResponse({
+      identity_types_supported: ["anonymous", "identity_assertion"],
+      register: 'POST JSON { type: "anonymous" }',
+    });
+  }
+  const body = await readBody(request);
+  const type = body.type || "anonymous";
+  if (type !== "anonymous" && type !== "identity_assertion") {
+    return jsonResponse(
+      {error: "unsupported_identity_type", error_description: type},
+      "application/json; charset=utf-8",
+      {},
+      400,
+    );
+  }
+  const issued = issue(`agent:${mintOpaque()}`);
+  return jsonResponse(tokenPayload(origin, issued, {type}));
+}
+
+export async function handleClaim(request: Request): Promise<Response> {
+  const origin = publicOrigin(request);
+  const body = request.method === "POST" ? await readBody(request) : {};
+  const claimToken = body.claim_token || body.token;
+  if (claimToken && !assertions.has(claimToken) && !tokens.has(claimToken)) {
+    return jsonResponse(
+      {error: "invalid_grant", error_description: "unknown claim_token"},
+      "application/json; charset=utf-8",
+      {},
+      400,
+    );
+  }
+  return jsonResponse({
+    user_code: "WALLET",
+    verification_uri: `${origin}/delegation`,
+    verification_uri_complete: `${origin}/delegation`,
+    expires_in: 600,
+    interval: 5,
+    message:
+      "Connect an Aptos wallet on the verification URI to associate this agent with a human operator. Read APIs do not require a claim.",
+  });
+}
+
+export async function handleToken(request: Request): Promise<Response> {
+  const origin = publicOrigin(request);
+  const body = await readBody(request);
+  const grant = body.grant_type || "client_credentials";
+
+  if (grant === "client_credentials") {
+    const issued = issue("client_credentials");
+    return jsonResponse(tokenPayload(origin, issued));
+  }
+
+  if (grant === "urn:ietf:params:oauth:grant-type:jwt-bearer") {
+    const assertion = body.assertion;
+    if (!assertion || !assertions.has(assertion)) {
+      return jsonResponse(
+        {error: "invalid_grant"},
+        "application/json; charset=utf-8",
+        {},
+        400,
+      );
+    }
+    const existing = assertions.get(assertion)!;
+    const issued = issue(existing.sub, existing.scope);
+    return jsonResponse(tokenPayload(origin, issued));
+  }
+
+  if (grant === "urn:workos:agent-auth:grant-type:claim") {
+    return jsonResponse(
+      {
+        error: "authorization_pending",
+        error_description:
+          "Waiting for the user to connect a wallet at /delegation",
+      },
+      "application/json; charset=utf-8",
+      {},
+      400,
+    );
+  }
+
+  return jsonResponse(
+    {error: "unsupported_grant_type"},
+    "application/json; charset=utf-8",
+    {},
+    400,
+  );
+}
+
+export async function handleRevoke(request: Request): Promise<Response> {
+  const body = request.method === "POST" ? await readBody(request) : {};
+  const token = body.token;
+  if (token) {
+    tokens.delete(token);
+    assertions.delete(token);
+  }
+  return new Response(null, {status: 200});
+}
+
+export function handleUserinfo(): Response {
+  return jsonResponse({
+    sub: "public-reader",
+    scope: READ_SCOPE,
+  });
+}
+
+export function handleEventNotify(): Response {
+  return jsonResponse({ok: true});
+}

--- a/src/lib/agent-discovery/oauth.ts
+++ b/src/lib/agent-discovery/oauth.ts
@@ -1,0 +1,168 @@
+import {absoluteUrl} from "~/lib/agent-discovery/origin";
+
+export const READ_SCOPE = "proposals:read";
+
+export function issuerUrl(origin: string): string {
+  return origin;
+}
+
+export function buildProtectedResourceMetadata(origin: string) {
+  return {
+    resource: `${origin}/`,
+    resource_name: "Aptos Governance",
+    authorization_servers: [issuerUrl(origin)],
+    scopes_supported: [READ_SCOPE],
+    bearer_methods_supported: ["header"],
+    resource_documentation: absoluteUrl(origin, "/docs/api"),
+  };
+}
+
+export function buildAgentAuthBlock(origin: string) {
+  return {
+    skill: absoluteUrl(origin, "/auth.md"),
+    register_uri: absoluteUrl(origin, "/agent/identity"),
+    identity_endpoint: absoluteUrl(origin, "/agent/identity"),
+    claim_endpoint: absoluteUrl(origin, "/agent/identity/claim"),
+    claim_uri: absoluteUrl(origin, "/agent/identity/claim"),
+    revocation_uri: absoluteUrl(origin, "/oauth2/revoke"),
+    events_endpoint: absoluteUrl(origin, "/agent/event/notify"),
+    identity_types_supported: ["anonymous", "identity_assertion"],
+    identity_assertion: {
+      assertion_types_supported: [
+        "urn:ietf:params:oauth:token-type:id-jag",
+        "verified_email",
+      ],
+    },
+    anonymous: {
+      credential_types_supported: ["access_token"],
+      claim_uri: absoluteUrl(origin, "/agent/identity/claim"),
+    },
+    events_supported: [
+      "https://schemas.workos.com/events/agent/auth/identity/assertion/revoked",
+    ],
+  };
+}
+
+export function buildAuthorizationServerMetadata(origin: string) {
+  const issuer = issuerUrl(origin);
+  return {
+    ...buildProtectedResourceMetadata(origin),
+    issuer,
+    authorization_endpoint: absoluteUrl(origin, "/oauth2/authorize"),
+    token_endpoint: absoluteUrl(origin, "/oauth2/token"),
+    revocation_endpoint: absoluteUrl(origin, "/oauth2/revoke"),
+    jwks_uri: absoluteUrl(origin, "/.well-known/jwks.json"),
+    response_types_supported: ["code", "token"],
+    grant_types_supported: [
+      "client_credentials",
+      "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      "urn:workos:agent-auth:grant-type:claim",
+    ],
+    token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
+    code_challenge_methods_supported: ["S256"],
+    service_documentation: absoluteUrl(origin, "/docs/api"),
+    agent_auth: buildAgentAuthBlock(origin),
+  };
+}
+
+export function buildOpenIdConfiguration(origin: string) {
+  return {
+    ...buildAuthorizationServerMetadata(origin),
+    userinfo_endpoint: absoluteUrl(origin, "/oauth2/userinfo"),
+    id_token_signing_alg_values_supported: ["none"],
+    subject_types_supported: ["public"],
+    claims_supported: ["iss", "sub", "aud", "exp", "iat", "scope"],
+  };
+}
+
+export function buildJwks() {
+  return {keys: [] as unknown[]};
+}
+
+export function buildAuthMd(_origin?: string): string {
+  return `# auth.md
+
+You are an agent. Aptos Governance supports **agentic registration** for its public read API. Voting stays on-chain through a user's Aptos wallet.
+
+Follow discover → register → (optional claim) → exchange → call API. Do not skip ahead. Do not POST here during a passive scan.
+
+## Audience
+
+- **Resource:** this origin (\`/\`)
+- **Human app:** \`/\`
+- **Read API:** \`/api/proposals\`
+- **MCP:** \`/mcp\`
+
+Most data is public. A bearer token is optional identification for \`proposals:read\`. There is no OAuth grant that can cast a governance vote.
+
+## Step 1 — Discover
+
+### 1a. Protected Resource Metadata
+
+\`GET /.well-known/oauth-protected-resource\`
+
+Fields: \`resource\`, \`authorization_servers\`, \`scopes_supported\` (\`${READ_SCOPE}\`), \`bearer_methods_supported\` (\`header\`).
+
+### 1b. Authorization Server metadata
+
+\`GET /.well-known/oauth-authorization-server\`
+
+Also published as OpenID discovery at \`/.well-known/openid-configuration\`.
+
+Read \`issuer\`, \`token_endpoint\`, \`jwks_uri\`, \`grant_types_supported\`, and the \`agent_auth\` block (\`skill\`, \`register_uri\`, \`identity_types_supported\`).
+
+## Step 2 — Pick a method
+
+1. **Anonymous** (recommended for read-only agents): POST \`{"type":"anonymous"}\` to \`register_uri\`.
+2. **Identity assertion** if you have an ID-JAG for this audience (\`urn:ietf:params:oauth:token-type:id-jag\`).
+3. **Verified email** is advertised for claim ceremony completeness; this deployment does not send email. Use anonymous instead.
+
+## Step 3 — Register
+
+\`POST /agent/identity\`
+
+\`Content-Type: application/json\`
+
+\`\`\`json
+{ "type": "anonymous" }
+\`\`\`
+
+Response includes \`identity_assertion\`, \`claim_token\`, and may include an \`access_token\` already usable as \`Authorization: Bearer\`.
+
+## Step 4 — Claim (optional)
+
+Anonymous credentials can stay unclaimed. To attach a human later, POST to \`/agent/identity/claim\` with the \`claim_token\`. The user completes the ceremony in the browser at \`/delegation\` by connecting an Aptos wallet.
+
+## Step 5 — Token
+
+\`POST /oauth2/token\`
+
+- \`grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=<identity_assertion>\`
+- or \`grant_type=client_credentials&scope=${READ_SCOPE}\` (no client secret)
+
+## Step 6 — Call the API
+
+Send \`Authorization: Bearer <access_token>\` if you have one. Omitting the header is allowed for GET \`/api/*\`.
+
+Revoke: \`POST /oauth2/revoke\` with \`token=<access_token>\`.
+`;
+}
+
+export function buildAuthorizeHtml(origin: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Aptos Governance authorization</title>
+</head>
+<body>
+  <main>
+    <h1>Authorization</h1>
+    <p>This authorization server issues optional <code>${READ_SCOPE}</code> tokens for the public governance read API.</p>
+    <p>Agents should follow <a href="/auth.md">auth.md</a> and register at <code>POST /agent/identity</code> rather than using an interactive login form.</p>
+    <p>On-chain votes require an Aptos wallet at <a href="/">${origin}</a>.</p>
+  </main>
+</body>
+</html>
+`;
+}

--- a/src/lib/agent-discovery/openapi.ts
+++ b/src/lib/agent-discovery/openapi.ts
@@ -1,0 +1,149 @@
+import {absoluteUrl} from "~/lib/agent-discovery/origin";
+
+export function buildOpenApiDocument(origin: string) {
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: "Aptos Governance API",
+      version: "1.0.0",
+      description:
+        "Public read API for on-chain Aptos Improvement Proposals. Voting remains wallet-signed on chain.",
+    },
+    servers: [{url: origin, description: "This deployment"}],
+    paths: {
+      "/api/health": {
+        get: {
+          operationId: "getHealth",
+          summary: "Liveness and discovery pointers",
+          responses: {
+            "200": {
+              description: "Service is up",
+              content: {
+                "application/json": {
+                  schema: {type: "object", additionalProperties: true},
+                },
+              },
+            },
+          },
+        },
+      },
+      "/api/proposals": {
+        get: {
+          operationId: "listProposals",
+          summary: "List proposals, newest first",
+          parameters: [
+            {
+              name: "page",
+              in: "query",
+              schema: {type: "integer", minimum: 0, default: 0},
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Paginated proposal list",
+              content: {
+                "application/json": {
+                  schema: {type: "object", additionalProperties: true},
+                },
+              },
+            },
+          },
+        },
+      },
+      "/api/proposals/{proposalId}": {
+        get: {
+          operationId: "getProposal",
+          summary: "Get one proposal",
+          parameters: [
+            {
+              name: "proposalId",
+              in: "path",
+              required: true,
+              schema: {type: "string", pattern: "^[0-9]+$"},
+            },
+          ],
+          responses: {
+            "200": {description: "Proposal detail"},
+            "404": {description: "Unknown proposal id"},
+          },
+        },
+      },
+      "/api/proposals/{proposalId}/votes": {
+        get: {
+          operationId: "listProposalVotes",
+          summary: "Paginated per-pool votes for a proposal",
+          parameters: [
+            {
+              name: "proposalId",
+              in: "path",
+              required: true,
+              schema: {type: "string", pattern: "^[0-9]+$"},
+            },
+            {
+              name: "page",
+              in: "query",
+              schema: {type: "integer", minimum: 0, default: 0},
+            },
+          ],
+          responses: {
+            "200": {description: "Vote page"},
+          },
+        },
+      },
+    },
+  };
+}
+
+export function buildApiDocsMarkdown(origin: string): string {
+  return `# Aptos Governance API
+
+Public JSON API for on-chain Aptos Improvement Proposals (AIPs). HTML UI: ${origin}/
+
+## Authentication
+
+Read endpoints are public. Voting is **not** exposed here: users sign \`0x1::aptos_governance\` transactions in a wallet. Agent registration: ${origin}/auth.md
+
+## Endpoints
+
+- \`GET /api/health\` — liveness
+- \`GET /api/proposals?page=0\` — newest-first list (20 per page)
+- \`GET /api/proposals/{id}\` — one proposal plus first votes page
+- \`GET /api/proposals/{id}/votes?page=0\` — voter breakdown
+
+OpenAPI: ${origin}/openapi.json
+
+## MCP
+
+Streamable HTTP: \`POST ${origin}/mcp\`
+Server card: ${origin}/.well-known/mcp/server-card.json
+
+## Discovery
+
+- API catalog: ${origin}/.well-known/api-catalog
+- ARD catalog: ${origin}/.well-known/ai-catalog.json
+- Skills: ${origin}/.well-known/agent-skills/index.json
+`;
+}
+
+export function buildApiDocsHtml(origin: string): string {
+  const md = buildApiDocsMarkdown(origin);
+  const escaped = md
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Aptos Governance API</title>
+  <link rel="service-desc" href="/openapi.json" type="application/json"/>
+  <link rel="api-catalog" href="/.well-known/api-catalog"/>
+</head>
+<body>
+  <main>
+    <pre>${escaped}</pre>
+  </main>
+</body>
+</html>
+`;
+}

--- a/src/lib/agent-discovery/origin.ts
+++ b/src/lib/agent-discovery/origin.ts
@@ -1,0 +1,35 @@
+import {readEnv} from "~/lib/governance/api-config";
+
+/** Production origin for Aptos Governance. */
+export const DEFAULT_SITE_ORIGIN = "https://governance.aptosfoundation.org";
+
+export function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+/**
+ * Public origin for absolute discovery URLs. Prefers SITE_ORIGIN, then
+ * forwarded host headers (Vercel), then the request URL.
+ */
+export function publicOrigin(request: Request): string {
+  const fromEnv = readEnv("SITE_ORIGIN");
+  if (fromEnv) return trimTrailingSlash(fromEnv);
+
+  const forwardedHost = request.headers.get("x-forwarded-host");
+  if (forwardedHost) {
+    const host = forwardedHost.split(",")[0]?.trim();
+    if (host) {
+      const forwardedProto =
+        request.headers.get("x-forwarded-proto") ?? "https";
+      const proto = forwardedProto.split(",")[0]?.trim() || "https";
+      return `${proto}://${host}`;
+    }
+  }
+
+  return new URL(request.url).origin;
+}
+
+export function absoluteUrl(origin: string, path: string): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${trimTrailingSlash(origin)}${normalizedPath}`;
+}

--- a/src/lib/agent-discovery/rest.ts
+++ b/src/lib/agent-discovery/rest.ts
@@ -1,0 +1,97 @@
+import {jsonResponse, notFound} from "~/lib/agent-discovery/http";
+import {publicOrigin} from "~/lib/agent-discovery/origin";
+import {loadProposalDetail} from "~/lib/governance/fetch-proposal";
+import {
+  fetchProposalVotesPage,
+  PROPOSAL_VOTES_PAGE_SIZE,
+} from "~/lib/governance/fetch-proposal-votes";
+import {loadProposalListPage} from "~/lib/governance/fetch-proposals";
+import {proposalToJson} from "~/lib/governance/json";
+
+function pageFrom(request: Request): number {
+  const page = Number(new URL(request.url).searchParams.get("page") ?? "0");
+  return Number.isFinite(page) && page >= 0 ? Math.floor(page) : 0;
+}
+
+export function healthPayload(origin: string) {
+  return {
+    status: "ok",
+    service: "aptos-governance",
+    docs: `${origin}/docs/api`,
+    openapi: `${origin}/openapi.json`,
+  };
+}
+
+export async function handleListProposals(request: Request): Promise<Response> {
+  const page = pageFrom(request);
+  const result = await loadProposalListPage(page);
+  return jsonResponse({
+    items: result.items.map(proposalToJson),
+    totalCount: result.totalCount,
+    page: result.page,
+    pageSize: result.pageSize,
+  });
+}
+
+export async function handleGetProposal(
+  request: Request,
+  proposalId: string,
+): Promise<Response> {
+  if (!/^\d+$/.test(proposalId)) {
+    return notFound("proposalId must be a non-negative integer");
+  }
+  try {
+    const result = await loadProposalDetail(proposalId, pageFrom(request));
+    return jsonResponse({
+      proposal: proposalToJson(result.proposal),
+      votes: {
+        items: result.votes.items.map((vote) => ({
+          stakingPoolAddress: vote.stakingPoolAddress,
+          shouldPass: vote.shouldPass,
+          numVotes: vote.numVotes.toString(),
+        })),
+        totalCount: result.votes.totalCount,
+        page: result.votes.page,
+        pageSize: result.votes.pageSize,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    if (/does not exist/.test(message)) {
+      return notFound(message);
+    }
+    return jsonResponse(
+      {error: message},
+      "application/json; charset=utf-8",
+      {},
+      500,
+    );
+  }
+}
+
+export async function handleListVotes(
+  request: Request,
+  proposalId: string,
+): Promise<Response> {
+  if (!/^\d+$/.test(proposalId)) {
+    return notFound("proposalId must be a non-negative integer");
+  }
+  const page = await fetchProposalVotesPage(proposalId, {
+    page: pageFrom(request),
+    pageSize: PROPOSAL_VOTES_PAGE_SIZE,
+  });
+  return jsonResponse({
+    items: page.items.map((vote) => ({
+      stakingPoolAddress: vote.stakingPoolAddress,
+      shouldPass: vote.shouldPass,
+      numVotes: vote.numVotes.toString(),
+    })),
+    totalCount: page.totalCount,
+    page: page.page,
+    pageSize: page.pageSize,
+  });
+}
+
+export function handleHealth(request: Request): Response {
+  return jsonResponse(healthPayload(publicOrigin(request)));
+}

--- a/src/lib/agent-discovery/robots.ts
+++ b/src/lib/agent-discovery/robots.ts
@@ -1,0 +1,25 @@
+import {absoluteUrl} from "~/lib/agent-discovery/origin";
+
+export function buildRobotsTxt(origin: string): string {
+  const sitemap = absoluteUrl(origin, "/sitemap.xml");
+  const agentmap = absoluteUrl(origin, "/.well-known/ai-catalog.json");
+  return [
+    "User-agent: *",
+    "Allow: /",
+    "Allow: /proposal/",
+    "Allow: /delegation",
+    "Allow: /docs/",
+    "Allow: /api/",
+    "Allow: /.well-known/",
+    "Allow: /sitemap.xml",
+    "Allow: /auth.md",
+    "Allow: /openapi.json",
+    "Disallow: /_serverFn",
+    "Disallow: /_tanstack",
+    "Content-Signal: ai-train=no, search=yes, ai-input=yes",
+    "",
+    `Sitemap: ${sitemap}`,
+    `Agentmap: ${agentmap}`,
+    "",
+  ].join("\n");
+}

--- a/src/lib/agent-discovery/route-handler.ts
+++ b/src/lib/agent-discovery/route-handler.ts
@@ -1,0 +1,17 @@
+import {handleAgentDiscoveryRequest} from "~/lib/agent-discovery/dispatch";
+
+export async function agentDiscoveryHandler({
+  request,
+}: {
+  request: Request;
+}): Promise<Response> {
+  const response = await handleAgentDiscoveryRequest(request);
+  return response ?? new Response("Not found\n", {status: 404});
+}
+
+export const AGENT_DISCOVERY_HANDLERS = {
+  GET: agentDiscoveryHandler,
+  HEAD: agentDiscoveryHandler,
+  POST: agentDiscoveryHandler,
+  OPTIONS: agentDiscoveryHandler,
+};

--- a/src/lib/agent-discovery/sitemap.ts
+++ b/src/lib/agent-discovery/sitemap.ts
@@ -1,0 +1,54 @@
+import {absoluteUrl} from "~/lib/agent-discovery/origin";
+import {loadProposalCount} from "~/lib/governance/load-forum";
+
+const SITEMAP_URL_LIMIT = 50_000;
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+function urlEntry(loc: string, changefreq: string, priority: string): string {
+  return [
+    "  <url>",
+    `    <loc>${escapeXml(loc)}</loc>`,
+    `    <changefreq>${changefreq}</changefreq>`,
+    `    <priority>${priority}</priority>`,
+    "  </url>",
+  ].join("\n");
+}
+
+export async function buildSitemapXml(origin: string): Promise<string> {
+  const entries = [
+    urlEntry(absoluteUrl(origin, "/"), "hourly", "1.0"),
+    urlEntry(absoluteUrl(origin, "/delegation"), "daily", "0.4"),
+    urlEntry(absoluteUrl(origin, "/docs/api"), "weekly", "0.5"),
+    urlEntry(absoluteUrl(origin, "/auth.md"), "weekly", "0.3"),
+  ];
+
+  let proposalCount = 0;
+  try {
+    proposalCount = await loadProposalCount();
+  } catch {
+    proposalCount = 0;
+  }
+
+  const maxId = Math.min(proposalCount, SITEMAP_URL_LIMIT - entries.length) - 1;
+  for (let id = 0; id <= maxId; id++) {
+    entries.push(
+      urlEntry(absoluteUrl(origin, `/proposal/${id}`), "hourly", "0.8"),
+    );
+  }
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...entries,
+    "</urlset>",
+    "",
+  ].join("\n");
+}

--- a/src/lib/agent-discovery/skills.ts
+++ b/src/lib/agent-discovery/skills.ts
@@ -1,0 +1,124 @@
+import {createHash} from "node:crypto";
+import {absoluteUrl} from "~/lib/agent-discovery/origin";
+
+const SCHEMA = "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
+
+export interface SkillDefinition {
+  name: string;
+  description: string;
+  markdown: string;
+}
+
+export const GOVERNANCE_SKILLS: SkillDefinition[] = [
+  {
+    name: "list-proposals",
+    description:
+      "List on-chain Aptos Improvement Proposals (AIPs) with status, tallies, and pagination.",
+    markdown: `---
+name: list-proposals
+description: List on-chain Aptos Improvement Proposals (AIPs) with status, tallies, and pagination.
+---
+
+# List Aptos governance proposals
+
+Use this skill when the user wants a catalog of current or historical Aptos on-chain proposals.
+
+## HTTP
+
+\`GET /api/proposals?page=0\`
+
+Response fields include \`proposalId\`, \`status\` (\`active\` | \`passed\` | \`executed\` | \`failed\`), \`yesVotes\`, \`noVotes\`, and verified off-chain metadata when the on-chain hash matches.
+
+## MCP
+
+Call tool \`list_proposals\` on the Streamable HTTP MCP server at \`/mcp\`.
+
+## WebMCP
+
+On the governance homepage, the browser tool \`list_proposals\` returns the same JSON.
+`,
+  },
+  {
+    name: "get-proposal",
+    description:
+      "Fetch one Aptos governance proposal by numeric id, including description and vote breakdown.",
+    markdown: `---
+name: get-proposal
+description: Fetch one Aptos governance proposal by numeric id, including description and vote breakdown.
+---
+
+# Get an Aptos governance proposal
+
+Use this skill when the user names a proposal id or wants details for a single AIP.
+
+## HTTP
+
+\`GET /api/proposals/{proposalId}\`
+
+Votes page: \`GET /api/proposals/{proposalId}/votes?page=0\`
+
+Human page: \`/proposal/{proposalId}\`
+
+## MCP
+
+Call tool \`get_proposal\` with \`{ "proposalId": "<id>" }\`.
+`,
+  },
+  {
+    name: "vote-on-proposal",
+    description:
+      "Cast an on-chain Aptos governance vote through a connected wallet. Agents cannot vote without a user wallet signature.",
+    markdown: `---
+name: vote-on-proposal
+description: Cast an on-chain Aptos governance vote through a connected wallet. Agents cannot vote without a user wallet signature.
+---
+
+# Vote on an Aptos governance proposal
+
+Voting is an on-chain transaction against \`0x1::aptos_governance\`. This app never holds private keys.
+
+## Agent flow
+
+1. Open \`/proposal/{proposalId}\` in the user's browser.
+2. Ask the user to connect an AIP-62 wallet (Petra or any registered wallet).
+3. Use the on-page voting panel. The user must review and sign the transaction.
+4. Do not attempt to submit a vote through the REST or MCP APIs — they are read-only.
+
+## Registration
+
+Read \`/auth.md\` for agent registration. Read APIs do not require a token.
+`,
+  },
+];
+
+export function skillMarkdown(skill: SkillDefinition, origin: string): string {
+  return skill.markdown.replaceAll("{origin}", origin);
+}
+
+export function skillDigest(markdown: string): string {
+  const hex = createHash("sha256").update(markdown, "utf8").digest("hex");
+  return `sha256:${hex}`;
+}
+
+export function buildSkillsIndex(origin: string) {
+  return {
+    $schema: SCHEMA,
+    skills: GOVERNANCE_SKILLS.map((skill) => {
+      const markdown = skillMarkdown(skill, origin);
+      return {
+        name: skill.name,
+        type: "skill-md" as const,
+        description: skill.description,
+        url: absoluteUrl(
+          origin,
+          `/.well-known/agent-skills/${skill.name}/SKILL.md`,
+        ),
+        digest: skillDigest(markdown),
+      };
+    }),
+  };
+}
+
+export function findSkill(name: string): SkillDefinition | undefined {
+  return GOVERNANCE_SKILLS.find((skill) => skill.name === name);
+}

--- a/src/lib/governance/fetch-proposal.ts
+++ b/src/lib/governance/fetch-proposal.ts
@@ -31,63 +31,70 @@ export interface ProposalDetailResult {
   votes: ProposalVotesPage;
 }
 
+export async function loadProposalDetail(
+  proposalId: string,
+  votesPage = 0,
+): Promise<ProposalDetailResult> {
+  const forum = await loadVotingForum();
+
+  const nextProposalId = BigInt(forum.next_proposal_id);
+  if (BigInt(proposalId) >= nextProposalId) {
+    throw new Error(
+      `Proposal ${proposalId} does not exist (only 0..${(nextProposalId - 1n).toString()} exist)`,
+    );
+  }
+
+  const aptos = getAptosClient();
+
+  const [raw, votes] = await Promise.all([
+    proposalItemCache.getOrSet(proposalId, async () =>
+      aptos.getTableItem<RawProposal>({
+        handle: forum.proposals.handle,
+        data: {
+          key_type: "u64",
+          value_type: VOTING_FORUM_PROPOSAL_VALUE_TYPE,
+          key: proposalId,
+        },
+      }),
+    ) as Promise<RawProposal>,
+    // Indexer failure degrades to an empty vote list rather than
+    // failing the whole page — the fullnode-sourced yes/no tally
+    // fetched above remains authoritative either way (design spec §6.3).
+    fetchProposalVotesPage(proposalId, {
+      page: votesPage,
+      pageSize: PROPOSAL_VOTES_PAGE_SIZE,
+    }).catch(
+      (): ProposalVotesPage => ({
+        items: [],
+        totalCount: 0,
+        page: votesPage,
+        pageSize: PROPOSAL_VOTES_PAGE_SIZE,
+      }),
+    ),
+  ]);
+
+  const core = parseRawProposalCore(proposalId, raw);
+  const nowSecs = BigInt(Math.floor(Date.now() / 1000));
+
+  const metadataResult =
+    core.metadataLocation && core.metadataHashHex
+      ? await fetchAndVerifyProposalMetadata(
+          core.metadataLocation,
+          core.metadataHashHex,
+        )
+      : {
+          verified: false as const,
+          reason: "proposal has no metadata_location/metadata_hash set",
+        };
+
+  return {
+    proposal: buildProposalListItem(core, metadataResult, nowSecs),
+    votes,
+  };
+}
+
 export const getProposalDetail = createServerFn({method: "GET"})
   .validator(getProposalInputSchema)
   .handler(async ({data}): Promise<ProposalDetailResult> => {
-    const forum = await loadVotingForum();
-
-    const nextProposalId = BigInt(forum.next_proposal_id);
-    if (BigInt(data.proposalId) >= nextProposalId) {
-      throw new Error(
-        `Proposal ${data.proposalId} does not exist (only 0..${(nextProposalId - 1n).toString()} exist)`,
-      );
-    }
-
-    const aptos = getAptosClient();
-
-    const [raw, votes] = await Promise.all([
-      proposalItemCache.getOrSet(data.proposalId, async () =>
-        aptos.getTableItem<RawProposal>({
-          handle: forum.proposals.handle,
-          data: {
-            key_type: "u64",
-            value_type: VOTING_FORUM_PROPOSAL_VALUE_TYPE,
-            key: data.proposalId,
-          },
-        }),
-      ) as Promise<RawProposal>,
-      // Indexer failure degrades to an empty vote list rather than
-      // failing the whole page — the fullnode-sourced yes/no tally
-      // fetched above remains authoritative either way (design spec §6.3).
-      fetchProposalVotesPage(data.proposalId, {
-        page: data.votesPage,
-        pageSize: PROPOSAL_VOTES_PAGE_SIZE,
-      }).catch(
-        (): ProposalVotesPage => ({
-          items: [],
-          totalCount: 0,
-          page: data.votesPage,
-          pageSize: PROPOSAL_VOTES_PAGE_SIZE,
-        }),
-      ),
-    ]);
-
-    const core = parseRawProposalCore(data.proposalId, raw);
-    const nowSecs = BigInt(Math.floor(Date.now() / 1000));
-
-    const metadataResult =
-      core.metadataLocation && core.metadataHashHex
-        ? await fetchAndVerifyProposalMetadata(
-            core.metadataLocation,
-            core.metadataHashHex,
-          )
-        : {
-            verified: false as const,
-            reason: "proposal has no metadata_location/metadata_hash set",
-          };
-
-    return {
-      proposal: buildProposalListItem(core, metadataResult, nowSecs),
-      votes,
-    };
+    return loadProposalDetail(data.proposalId, data.votesPage);
   });

--- a/src/lib/governance/fetch-proposals.ts
+++ b/src/lib/governance/fetch-proposals.ts
@@ -53,50 +53,56 @@ async function loadRawProposal(
  * resource on mainnet on 2026-08-20) — "listing" means picking a slice
  * of that id range and fetching each proposal from the proposals table.
  */
+export async function loadProposalListPage(
+  page: number,
+): Promise<ListProposalsResult> {
+  return proposalListCache.getOrSet(`page:${page}`, async () => {
+    const forum = await loadVotingForum();
+
+    const totalCount = Number(forum.next_proposal_id);
+    const nowSecs = BigInt(Math.floor(Date.now() / 1000));
+
+    const highestId = totalCount - 1 - page * PAGE_SIZE;
+    const lowestId = Math.max(0, highestId - PAGE_SIZE + 1);
+
+    if (highestId < 0) {
+      return {items: [], totalCount, page, pageSize: PAGE_SIZE};
+    }
+
+    const ids: number[] = [];
+    for (let id = highestId; id >= lowestId; id--) {
+      ids.push(id);
+    }
+
+    const items = await Promise.all(
+      ids.map(async (id) => {
+        const raw = await loadRawProposal(
+          forum.proposals.handle,
+          id.toString(),
+        );
+        const core = parseRawProposalCore(id.toString(), raw);
+
+        const metadataResult =
+          core.metadataLocation && core.metadataHashHex
+            ? await fetchAndVerifyProposalMetadata(
+                core.metadataLocation,
+                core.metadataHashHex,
+              )
+            : {
+                verified: false as const,
+                reason: "proposal has no metadata_location/metadata_hash set",
+              };
+
+        return buildProposalListItem(core, metadataResult, nowSecs);
+      }),
+    );
+
+    return {items, totalCount, page, pageSize: PAGE_SIZE};
+  }) as Promise<ListProposalsResult>;
+}
+
 export const listProposals = createServerFn({method: "GET"})
   .validator(listProposalsInputSchema)
   .handler(async ({data}): Promise<ListProposalsResult> => {
-    return proposalListCache.getOrSet(`page:${data.page}`, async () => {
-      const forum = await loadVotingForum();
-
-      const totalCount = Number(forum.next_proposal_id);
-      const nowSecs = BigInt(Math.floor(Date.now() / 1000));
-
-      const highestId = totalCount - 1 - data.page * PAGE_SIZE;
-      const lowestId = Math.max(0, highestId - PAGE_SIZE + 1);
-
-      if (highestId < 0) {
-        return {items: [], totalCount, page: data.page, pageSize: PAGE_SIZE};
-      }
-
-      const ids: number[] = [];
-      for (let id = highestId; id >= lowestId; id--) {
-        ids.push(id);
-      }
-
-      const items = await Promise.all(
-        ids.map(async (id) => {
-          const raw = await loadRawProposal(
-            forum.proposals.handle,
-            id.toString(),
-          );
-          const core = parseRawProposalCore(id.toString(), raw);
-
-          const metadataResult =
-            core.metadataLocation && core.metadataHashHex
-              ? await fetchAndVerifyProposalMetadata(
-                  core.metadataLocation,
-                  core.metadataHashHex,
-                )
-              : {
-                  verified: false as const,
-                  reason: "proposal has no metadata_location/metadata_hash set",
-                };
-
-          return buildProposalListItem(core, metadataResult, nowSecs);
-        }),
-      );
-
-      return {items, totalCount, page: data.page, pageSize: PAGE_SIZE};
-    }) as Promise<ListProposalsResult>;
+    return loadProposalListPage(data.page);
   });

--- a/src/lib/governance/json.ts
+++ b/src/lib/governance/json.ts
@@ -1,0 +1,27 @@
+import type {ProposalListItem} from "~/lib/governance/types";
+
+export function proposalToJson(proposal: ProposalListItem) {
+  return {
+    proposalId: proposal.proposalId,
+    proposer: proposal.proposer,
+    status: proposal.status,
+    creationTimeSecs: proposal.creationTimeSecs.toString(),
+    expirationSecs: proposal.expirationSecs.toString(),
+    resolutionTimeSecs: proposal.resolutionTimeSecs?.toString() ?? null,
+    minVoteThreshold: proposal.minVoteThreshold.toString(),
+    earlyResolutionVoteThreshold:
+      proposal.earlyResolutionVoteThreshold?.toString() ?? null,
+    yesVotes: proposal.yesVotes.toString(),
+    noVotes: proposal.noVotes.toString(),
+    executionHash: proposal.executionHash,
+    metadataLocation: proposal.metadataLocation,
+    metadataHashHex: proposal.metadataHashHex,
+    metadataVerified: proposal.metadataResult.verified,
+    metadata: proposal.metadataResult.verified
+      ? proposal.metadataResult.metadata
+      : null,
+    metadataReason: proposal.metadataResult.verified
+      ? null
+      : proposal.metadataResult.reason,
+  };
+}

--- a/src/lib/governance/load-forum.ts
+++ b/src/lib/governance/load-forum.ts
@@ -19,3 +19,10 @@ export async function loadVotingForum(): Promise<VotingForumResource> {
     });
   }) as Promise<VotingForumResource>;
 }
+
+/** Sequential proposal ids run from 0 to next_proposal_id - 1. */
+export async function loadProposalCount(): Promise<number> {
+  const forum = await loadVotingForum();
+  const count = Number(forum.next_proposal_id);
+  return Number.isFinite(count) && count > 0 ? count : 0;
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,12 +10,35 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AuthDotmdRouteImport } from './routes/auth[.]md'
 import { Route as DelegationRouteImport } from './routes/delegation'
+import { Route as McpRouteImport } from './routes/mcp'
+import { Route as OpenapiDotjsonRouteImport } from './routes/openapi[.]json'
+import { Route as RobotsDottxtRouteImport } from './routes/robots[.]txt'
+import { Route as SitemapDotxmlRouteImport } from './routes/sitemap[.]xml'
+import { Route as DotwellKnownSplatRouteImport } from './routes/[.]well-known.$'
+import { Route as AgentIdentityRouteImport } from './routes/agent.identity'
+import { Route as ApiHealthRouteImport } from './routes/api.health'
+import { Route as ApiProposalsRouteImport } from './routes/api.proposals'
+import { Route as DocsApiRouteImport } from './routes/docs.api'
+import { Route as Oauth2AuthorizeRouteImport } from './routes/oauth2.authorize'
+import { Route as Oauth2RevokeRouteImport } from './routes/oauth2.revoke'
+import { Route as Oauth2TokenRouteImport } from './routes/oauth2.token'
+import { Route as Oauth2UserinfoRouteImport } from './routes/oauth2.userinfo'
 import { Route as ProposalProposalIdRouteImport } from './routes/proposal.$proposalId'
+import { Route as AgentEventNotifyRouteImport } from './routes/agent.event.notify'
+import { Route as AgentIdentityClaimRouteImport } from './routes/agent.identity.claim'
+import { Route as ApiProposalsProposalIdRouteImport } from './routes/api.proposals.$proposalId'
+import { Route as ApiProposalsProposalIdVotesRouteImport } from './routes/api.proposals.$proposalId.votes'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AuthDotmdRoute = AuthDotmdRouteImport.update({
+  id: '/auth.md',
+  path: '/auth.md',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DelegationRoute = DelegationRouteImport.update({
@@ -23,40 +46,259 @@ const DelegationRoute = DelegationRouteImport.update({
   path: '/delegation',
   getParentRoute: () => rootRouteImport,
 } as any)
+const McpRoute = McpRouteImport.update({
+  id: '/mcp',
+  path: '/mcp',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OpenapiDotjsonRoute = OpenapiDotjsonRouteImport.update({
+  id: '/openapi.json',
+  path: '/openapi.json',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const RobotsDottxtRoute = RobotsDottxtRouteImport.update({
+  id: '/robots.txt',
+  path: '/robots.txt',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SitemapDotxmlRoute = SitemapDotxmlRouteImport.update({
+  id: '/sitemap.xml',
+  path: '/sitemap.xml',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DotwellKnownSplatRoute = DotwellKnownSplatRouteImport.update({
+  id: '/.well-known/$',
+  path: '/.well-known/$',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AgentIdentityRoute = AgentIdentityRouteImport.update({
+  id: '/agent/identity',
+  path: '/agent/identity',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiHealthRoute = ApiHealthRouteImport.update({
+  id: '/api/health',
+  path: '/api/health',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiProposalsRoute = ApiProposalsRouteImport.update({
+  id: '/api/proposals',
+  path: '/api/proposals',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DocsApiRoute = DocsApiRouteImport.update({
+  id: '/docs/api',
+  path: '/docs/api',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const Oauth2AuthorizeRoute = Oauth2AuthorizeRouteImport.update({
+  id: '/oauth2/authorize',
+  path: '/oauth2/authorize',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const Oauth2RevokeRoute = Oauth2RevokeRouteImport.update({
+  id: '/oauth2/revoke',
+  path: '/oauth2/revoke',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const Oauth2TokenRoute = Oauth2TokenRouteImport.update({
+  id: '/oauth2/token',
+  path: '/oauth2/token',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const Oauth2UserinfoRoute = Oauth2UserinfoRouteImport.update({
+  id: '/oauth2/userinfo',
+  path: '/oauth2/userinfo',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ProposalProposalIdRoute = ProposalProposalIdRouteImport.update({
   id: '/proposal/$proposalId',
   path: '/proposal/$proposalId',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AgentEventNotifyRoute = AgentEventNotifyRouteImport.update({
+  id: '/agent/event/notify',
+  path: '/agent/event/notify',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AgentIdentityClaimRoute = AgentIdentityClaimRouteImport.update({
+  id: '/claim',
+  path: '/claim',
+  getParentRoute: () => AgentIdentityRoute,
+} as any)
+const ApiProposalsProposalIdRoute = ApiProposalsProposalIdRouteImport.update({
+  id: '/$proposalId',
+  path: '/$proposalId',
+  getParentRoute: () => ApiProposalsRoute,
+} as any)
+const ApiProposalsProposalIdVotesRoute =
+  ApiProposalsProposalIdVotesRouteImport.update({
+    id: '/votes',
+    path: '/votes',
+    getParentRoute: () => ApiProposalsProposalIdRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/auth.md': typeof AuthDotmdRoute
   '/delegation': typeof DelegationRoute
+  '/mcp': typeof McpRoute
+  '/openapi.json': typeof OpenapiDotjsonRoute
+  '/robots.txt': typeof RobotsDottxtRoute
+  '/sitemap.xml': typeof SitemapDotxmlRoute
+  '/.well-known/$': typeof DotwellKnownSplatRoute
+  '/agent/identity': typeof AgentIdentityRouteWithChildren
+  '/api/health': typeof ApiHealthRoute
+  '/api/proposals': typeof ApiProposalsRouteWithChildren
+  '/docs/api': typeof DocsApiRoute
+  '/oauth2/authorize': typeof Oauth2AuthorizeRoute
+  '/oauth2/revoke': typeof Oauth2RevokeRoute
+  '/oauth2/token': typeof Oauth2TokenRoute
+  '/oauth2/userinfo': typeof Oauth2UserinfoRoute
   '/proposal/$proposalId': typeof ProposalProposalIdRoute
+  '/agent/event/notify': typeof AgentEventNotifyRoute
+  '/agent/identity/claim': typeof AgentIdentityClaimRoute
+  '/api/proposals/$proposalId': typeof ApiProposalsProposalIdRouteWithChildren
+  '/api/proposals/$proposalId/votes': typeof ApiProposalsProposalIdVotesRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/auth.md': typeof AuthDotmdRoute
   '/delegation': typeof DelegationRoute
+  '/mcp': typeof McpRoute
+  '/openapi.json': typeof OpenapiDotjsonRoute
+  '/robots.txt': typeof RobotsDottxtRoute
+  '/sitemap.xml': typeof SitemapDotxmlRoute
+  '/.well-known/$': typeof DotwellKnownSplatRoute
+  '/agent/identity': typeof AgentIdentityRouteWithChildren
+  '/api/health': typeof ApiHealthRoute
+  '/api/proposals': typeof ApiProposalsRouteWithChildren
+  '/docs/api': typeof DocsApiRoute
+  '/oauth2/authorize': typeof Oauth2AuthorizeRoute
+  '/oauth2/revoke': typeof Oauth2RevokeRoute
+  '/oauth2/token': typeof Oauth2TokenRoute
+  '/oauth2/userinfo': typeof Oauth2UserinfoRoute
   '/proposal/$proposalId': typeof ProposalProposalIdRoute
+  '/agent/event/notify': typeof AgentEventNotifyRoute
+  '/agent/identity/claim': typeof AgentIdentityClaimRoute
+  '/api/proposals/$proposalId': typeof ApiProposalsProposalIdRouteWithChildren
+  '/api/proposals/$proposalId/votes': typeof ApiProposalsProposalIdVotesRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/auth.md': typeof AuthDotmdRoute
   '/delegation': typeof DelegationRoute
+  '/mcp': typeof McpRoute
+  '/openapi.json': typeof OpenapiDotjsonRoute
+  '/robots.txt': typeof RobotsDottxtRoute
+  '/sitemap.xml': typeof SitemapDotxmlRoute
+  '/.well-known/$': typeof DotwellKnownSplatRoute
+  '/agent/identity': typeof AgentIdentityRouteWithChildren
+  '/api/health': typeof ApiHealthRoute
+  '/api/proposals': typeof ApiProposalsRouteWithChildren
+  '/docs/api': typeof DocsApiRoute
+  '/oauth2/authorize': typeof Oauth2AuthorizeRoute
+  '/oauth2/revoke': typeof Oauth2RevokeRoute
+  '/oauth2/token': typeof Oauth2TokenRoute
+  '/oauth2/userinfo': typeof Oauth2UserinfoRoute
   '/proposal/$proposalId': typeof ProposalProposalIdRoute
+  '/agent/event/notify': typeof AgentEventNotifyRoute
+  '/agent/identity/claim': typeof AgentIdentityClaimRoute
+  '/api/proposals/$proposalId': typeof ApiProposalsProposalIdRouteWithChildren
+  '/api/proposals/$proposalId/votes': typeof ApiProposalsProposalIdVotesRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/delegation' | '/proposal/$proposalId'
+  fullPaths:
+    | '/'
+    | '/auth.md'
+    | '/delegation'
+    | '/mcp'
+    | '/openapi.json'
+    | '/robots.txt'
+    | '/sitemap.xml'
+    | '/.well-known/$'
+    | '/agent/identity'
+    | '/api/health'
+    | '/api/proposals'
+    | '/docs/api'
+    | '/oauth2/authorize'
+    | '/oauth2/revoke'
+    | '/oauth2/token'
+    | '/oauth2/userinfo'
+    | '/proposal/$proposalId'
+    | '/agent/event/notify'
+    | '/agent/identity/claim'
+    | '/api/proposals/$proposalId'
+    | '/api/proposals/$proposalId/votes'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/delegation' | '/proposal/$proposalId'
-  id: '__root__' | '/' | '/delegation' | '/proposal/$proposalId'
+  to:
+    | '/'
+    | '/auth.md'
+    | '/delegation'
+    | '/mcp'
+    | '/openapi.json'
+    | '/robots.txt'
+    | '/sitemap.xml'
+    | '/.well-known/$'
+    | '/agent/identity'
+    | '/api/health'
+    | '/api/proposals'
+    | '/docs/api'
+    | '/oauth2/authorize'
+    | '/oauth2/revoke'
+    | '/oauth2/token'
+    | '/oauth2/userinfo'
+    | '/proposal/$proposalId'
+    | '/agent/event/notify'
+    | '/agent/identity/claim'
+    | '/api/proposals/$proposalId'
+    | '/api/proposals/$proposalId/votes'
+  id:
+    | '__root__'
+    | '/'
+    | '/auth.md'
+    | '/delegation'
+    | '/mcp'
+    | '/openapi.json'
+    | '/robots.txt'
+    | '/sitemap.xml'
+    | '/.well-known/$'
+    | '/agent/identity'
+    | '/api/health'
+    | '/api/proposals'
+    | '/docs/api'
+    | '/oauth2/authorize'
+    | '/oauth2/revoke'
+    | '/oauth2/token'
+    | '/oauth2/userinfo'
+    | '/proposal/$proposalId'
+    | '/agent/event/notify'
+    | '/agent/identity/claim'
+    | '/api/proposals/$proposalId'
+    | '/api/proposals/$proposalId/votes'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AuthDotmdRoute: typeof AuthDotmdRoute
   DelegationRoute: typeof DelegationRoute
+  McpRoute: typeof McpRoute
+  OpenapiDotjsonRoute: typeof OpenapiDotjsonRoute
+  RobotsDottxtRoute: typeof RobotsDottxtRoute
+  SitemapDotxmlRoute: typeof SitemapDotxmlRoute
+  DotwellKnownSplatRoute: typeof DotwellKnownSplatRoute
+  AgentIdentityRoute: typeof AgentIdentityRouteWithChildren
+  ApiHealthRoute: typeof ApiHealthRoute
+  ApiProposalsRoute: typeof ApiProposalsRouteWithChildren
+  DocsApiRoute: typeof DocsApiRoute
+  Oauth2AuthorizeRoute: typeof Oauth2AuthorizeRoute
+  Oauth2RevokeRoute: typeof Oauth2RevokeRoute
+  Oauth2TokenRoute: typeof Oauth2TokenRoute
+  Oauth2UserinfoRoute: typeof Oauth2UserinfoRoute
   ProposalProposalIdRoute: typeof ProposalProposalIdRoute
+  AgentEventNotifyRoute: typeof AgentEventNotifyRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -68,11 +310,109 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/auth.md': {
+      id: '/auth.md'
+      path: '/auth.md'
+      fullPath: '/auth.md'
+      preLoaderRoute: typeof AuthDotmdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/delegation': {
       id: '/delegation'
       path: '/delegation'
       fullPath: '/delegation'
       preLoaderRoute: typeof DelegationRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/mcp': {
+      id: '/mcp'
+      path: '/mcp'
+      fullPath: '/mcp'
+      preLoaderRoute: typeof McpRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/openapi.json': {
+      id: '/openapi.json'
+      path: '/openapi.json'
+      fullPath: '/openapi.json'
+      preLoaderRoute: typeof OpenapiDotjsonRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/robots.txt': {
+      id: '/robots.txt'
+      path: '/robots.txt'
+      fullPath: '/robots.txt'
+      preLoaderRoute: typeof RobotsDottxtRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/sitemap.xml': {
+      id: '/sitemap.xml'
+      path: '/sitemap.xml'
+      fullPath: '/sitemap.xml'
+      preLoaderRoute: typeof SitemapDotxmlRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/.well-known/$': {
+      id: '/.well-known/$'
+      path: '/.well-known/$'
+      fullPath: '/.well-known/$'
+      preLoaderRoute: typeof DotwellKnownSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/agent/identity': {
+      id: '/agent/identity'
+      path: '/agent/identity'
+      fullPath: '/agent/identity'
+      preLoaderRoute: typeof AgentIdentityRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/health': {
+      id: '/api/health'
+      path: '/api/health'
+      fullPath: '/api/health'
+      preLoaderRoute: typeof ApiHealthRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/proposals': {
+      id: '/api/proposals'
+      path: '/api/proposals'
+      fullPath: '/api/proposals'
+      preLoaderRoute: typeof ApiProposalsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/docs/api': {
+      id: '/docs/api'
+      path: '/docs/api'
+      fullPath: '/docs/api'
+      preLoaderRoute: typeof DocsApiRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/oauth2/authorize': {
+      id: '/oauth2/authorize'
+      path: '/oauth2/authorize'
+      fullPath: '/oauth2/authorize'
+      preLoaderRoute: typeof Oauth2AuthorizeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/oauth2/revoke': {
+      id: '/oauth2/revoke'
+      path: '/oauth2/revoke'
+      fullPath: '/oauth2/revoke'
+      preLoaderRoute: typeof Oauth2RevokeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/oauth2/token': {
+      id: '/oauth2/token'
+      path: '/oauth2/token'
+      fullPath: '/oauth2/token'
+      preLoaderRoute: typeof Oauth2TokenRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/oauth2/userinfo': {
+      id: '/oauth2/userinfo'
+      path: '/oauth2/userinfo'
+      fullPath: '/oauth2/userinfo'
+      preLoaderRoute: typeof Oauth2UserinfoRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/proposal/$proposalId': {
@@ -82,23 +422,105 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProposalProposalIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/agent/event/notify': {
+      id: '/agent/event/notify'
+      path: '/agent/event/notify'
+      fullPath: '/agent/event/notify'
+      preLoaderRoute: typeof AgentEventNotifyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/agent/identity/claim': {
+      id: '/agent/identity/claim'
+      path: '/claim'
+      fullPath: '/agent/identity/claim'
+      preLoaderRoute: typeof AgentIdentityClaimRouteImport
+      parentRoute: typeof AgentIdentityRoute
+    }
+    '/api/proposals/$proposalId': {
+      id: '/api/proposals/$proposalId'
+      path: '/$proposalId'
+      fullPath: '/api/proposals/$proposalId'
+      preLoaderRoute: typeof ApiProposalsProposalIdRouteImport
+      parentRoute: typeof ApiProposalsRoute
+    }
+    '/api/proposals/$proposalId/votes': {
+      id: '/api/proposals/$proposalId/votes'
+      path: '/votes'
+      fullPath: '/api/proposals/$proposalId/votes'
+      preLoaderRoute: typeof ApiProposalsProposalIdVotesRouteImport
+      parentRoute: typeof ApiProposalsProposalIdRoute
+    }
   }
 }
 
+interface AgentIdentityRouteChildren {
+  AgentIdentityClaimRoute: typeof AgentIdentityClaimRoute
+}
+
+const AgentIdentityRouteChildren: AgentIdentityRouteChildren = {
+  AgentIdentityClaimRoute: AgentIdentityClaimRoute,
+}
+
+const AgentIdentityRouteWithChildren = AgentIdentityRoute._addFileChildren(
+  AgentIdentityRouteChildren,
+)
+
+interface ApiProposalsProposalIdRouteChildren {
+  ApiProposalsProposalIdVotesRoute: typeof ApiProposalsProposalIdVotesRoute
+}
+
+const ApiProposalsProposalIdRouteChildren: ApiProposalsProposalIdRouteChildren =
+  {
+    ApiProposalsProposalIdVotesRoute: ApiProposalsProposalIdVotesRoute,
+  }
+
+const ApiProposalsProposalIdRouteWithChildren =
+  ApiProposalsProposalIdRoute._addFileChildren(
+    ApiProposalsProposalIdRouteChildren,
+  )
+
+interface ApiProposalsRouteChildren {
+  ApiProposalsProposalIdRoute: typeof ApiProposalsProposalIdRouteWithChildren
+}
+
+const ApiProposalsRouteChildren: ApiProposalsRouteChildren = {
+  ApiProposalsProposalIdRoute: ApiProposalsProposalIdRouteWithChildren,
+}
+
+const ApiProposalsRouteWithChildren = ApiProposalsRoute._addFileChildren(
+  ApiProposalsRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AuthDotmdRoute: AuthDotmdRoute,
   DelegationRoute: DelegationRoute,
+  McpRoute: McpRoute,
+  OpenapiDotjsonRoute: OpenapiDotjsonRoute,
+  RobotsDottxtRoute: RobotsDottxtRoute,
+  SitemapDotxmlRoute: SitemapDotxmlRoute,
+  DotwellKnownSplatRoute: DotwellKnownSplatRoute,
+  AgentIdentityRoute: AgentIdentityRouteWithChildren,
+  ApiHealthRoute: ApiHealthRoute,
+  ApiProposalsRoute: ApiProposalsRouteWithChildren,
+  DocsApiRoute: DocsApiRoute,
+  Oauth2AuthorizeRoute: Oauth2AuthorizeRoute,
+  Oauth2RevokeRoute: Oauth2RevokeRoute,
+  Oauth2TokenRoute: Oauth2TokenRoute,
+  Oauth2UserinfoRoute: Oauth2UserinfoRoute,
   ProposalProposalIdRoute: ProposalProposalIdRoute,
+  AgentEventNotifyRoute: AgentEventNotifyRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
 
 import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
+import type { startInstance } from './start.ts'
 declare module '@tanstack/react-start' {
   interface Register {
     ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
+    config: Awaited<ReturnType<typeof startInstance.getOptions>>
   }
 }

--- a/src/routes/[.]well-known.$.ts
+++ b/src/routes/[.]well-known.$.ts
@@ -1,0 +1,6 @@
+import {createFileRoute} from "@tanstack/react-router";
+import {AGENT_DISCOVERY_HANDLERS} from "~/lib/agent-discovery/route-handler";
+
+export const Route = createFileRoute("/.well-known/$")({
+  server: {handlers: AGENT_DISCOVERY_HANDLERS},
+});

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -6,6 +6,7 @@ import {
 } from "@tanstack/react-router";
 import {SiteFooter} from "~/components/SiteFooter";
 import {SiteHeader} from "~/components/SiteHeader";
+import {WebMcpTools} from "~/components/WebMcpTools";
 import {PAGE_SHELL_WIDTH_CLASS} from "~/lib/layout";
 import {AppWalletProvider} from "~/lib/wallet/provider";
 import appCss from "~/styles/app.css?url";
@@ -33,6 +34,14 @@ export const Route = createRootRoute({
       {rel: "icon", type: "image/svg+xml", href: "/favicon.svg"},
       {rel: "icon", type: "image/x-icon", href: "/favicon.ico"},
       {rel: "manifest", href: "/manifest.json"},
+      {rel: "api-catalog", href: "/.well-known/api-catalog"},
+      {rel: "service-desc", href: "/openapi.json", type: "application/json"},
+      {rel: "service-doc", href: "/docs/api", type: "text/markdown"},
+      {
+        rel: "describedby",
+        href: "/.well-known/ai-catalog.json",
+        type: "application/json",
+      },
       {rel: "preconnect", href: "https://fonts.googleapis.com"},
       {
         rel: "preconnect",
@@ -52,6 +61,7 @@ function RootComponent() {
   return (
     <RootDocument>
       <AppWalletProvider>
+        <WebMcpTools />
         <div id="app-shell">
           <SiteHeader />
           <div

--- a/src/routes/agent.event.notify.ts
+++ b/src/routes/agent.event.notify.ts
@@ -1,0 +1,6 @@
+import {createFileRoute} from "@tanstack/react-router";
+import {AGENT_DISCOVERY_HANDLERS} from "~/lib/agent-discovery/route-handler";
+
+export const Route = createFileRoute("/agent/event/notify")({
+  server: {handlers: AGENT_DISCOVERY_HANDLERS},
+});

--- a/src/routes/agent.identity.claim.ts
+++ b/src/routes/agent.identity.claim.ts
@@ -1,0 +1,6 @@
+import {createFileRoute} from "@tanstack/react-router";
+import {AGENT_DISCOVERY_HANDLERS} from "~/lib/agent-discovery/route-handler";
+
+export const Route = createFileRoute("/agent/identity/claim")({
+  server: {handlers: AGENT_DISCOVERY_HANDLERS},
+});

--- a/src/routes/agent.identity.ts
+++ b/src/routes/agent.identity.ts
@@ -1,0 +1,6 @@
+import {createFileRoute} from "@tanstack/react-router";
+import {AGENT_DISCOVERY_HANDLERS} from "~/lib/agent-discovery/route-handler";
+
+export const Route = createFileRoute("/agent/identity")({
+  server: {handlers: AGENT_DISCOVERY_HANDLERS},
+});

--- a/src/routes/api.health.ts
+++ b/src/routes/api.health.ts
@@ -1,0 +1,6 @@
+import {createFileRoute} from "@tanstack/react-router";
+import {AGENT_DISCOVERY_HANDLERS} from "~/lib/agent-discovery/route-handler";
+
+export const Route = createFileRoute("/api/health")({
+  server: {handlers: AGENT_DISCOVERY_HANDLERS},
+});

--- a/src/routes/api.proposals.$proposalId.ts
+++ b/src/routes/api.proposals.$proposalId.ts
@@ -1,0 +1,6 @@
+import {createFileRoute} from "@tanstack/react-router";
+import {AGENT_DISCOVERY_HANDLERS} from "~/lib/agent-discovery/route-handler";
+
+export const Route = createFileRoute("/api/proposals/$proposalId")({
+  server: {handlers: AGENT_DISCOVERY_HANDLERS},
+});

--- a/src/routes/api.proposals.$proposalId.votes.ts
+++ b/src/routes/api.proposals.$proposalId.votes.ts
@@ -1,0 +1,6 @@
+import {createFileRoute} from "@tanstack/react-router";
+import {AGENT_DISCOVERY_HANDLERS} from "~/lib/agent-discovery/route-handler";
+
+export const Route = createFileRoute("/api/proposals/$proposalId/votes")({
+  server: {handlers: AGENT_DISCOVERY_HANDLERS},
+});

--- a/src/routes/api.proposals.ts
+++ b/src/routes/api.proposals.ts
@@ -1,0 +1,6 @@
+import {createFileRoute} from "@tanstack/react-router";
+import {AGENT_DISCOVERY_HANDLERS} from "~/lib/agent-discovery/route-handler";
+
+export const Route = createFileRoute("/api/proposals")({
+  server: {handlers: AGENT_DISCOVERY_HANDLERS},
+});

--- a/src/routes/auth[.]md.ts
+++ b/src/routes/auth[.]md.ts
@@ -1,0 +1,6 @@
+import {createFileRoute} from "@tanstack/react-router";
+import {AGENT_DISCOVERY_HANDLERS} from "~/lib/agent-discovery/route-handler";
+
+export const Route = createFileRoute("/auth.md")({
+  server: {handlers: AGENT_DISCOVERY_HANDLERS},
+});

--- a/src/routes/docs.api.ts
+++ b/src/routes/docs.api.ts
@@ -1,0 +1,6 @@
+import {createFileRoute} from "@tanstack/react-router";
+import {AGENT_DISCOVERY_HANDLERS} from "~/lib/agent-discovery/route-handler";
+
+export const Route = createFileRoute("/docs/api")({
+  server: {handlers: AGENT_DISCOVERY_HANDLERS},
+});

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -6,6 +6,7 @@ import {ApiErrorAlert} from "~/components/ApiErrorAlert";
 import {PageHeader} from "~/components/PageHeader";
 import {PaginationBar} from "~/components/PaginationBar";
 import {ProposalsTable} from "~/components/ProposalsTable";
+import {homepageLinkHeaderValue} from "~/lib/agent-discovery/headers";
 import {fetchMyVotes} from "~/lib/governance/fetch-my-votes";
 import {listProposals} from "~/lib/governance/fetch-proposals";
 import type {ProposalStatus} from "~/lib/governance/types";
@@ -28,6 +29,9 @@ export const Route = createFileRoute("/")({
   validateSearch: searchSchema,
   loaderDeps: ({search}) => ({page: search.page}),
   loader: ({deps}) => listProposals({data: {page: deps.page}}),
+  headers: () => ({
+    Link: homepageLinkHeaderValue(),
+  }),
   component: Home,
 });
 

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -1,0 +1,6 @@
+import {createFileRoute} from "@tanstack/react-router";
+import {AGENT_DISCOVERY_HANDLERS} from "~/lib/agent-discovery/route-handler";
+
+export const Route = createFileRoute("/mcp")({
+  server: {handlers: AGENT_DISCOVERY_HANDLERS},
+});

--- a/src/routes/oauth2.authorize.ts
+++ b/src/routes/oauth2.authorize.ts
@@ -1,0 +1,6 @@
+import {createFileRoute} from "@tanstack/react-router";
+import {AGENT_DISCOVERY_HANDLERS} from "~/lib/agent-discovery/route-handler";
+
+export const Route = createFileRoute("/oauth2/authorize")({
+  server: {handlers: AGENT_DISCOVERY_HANDLERS},
+});

--- a/src/routes/oauth2.revoke.ts
+++ b/src/routes/oauth2.revoke.ts
@@ -1,0 +1,6 @@
+import {createFileRoute} from "@tanstack/react-router";
+import {AGENT_DISCOVERY_HANDLERS} from "~/lib/agent-discovery/route-handler";
+
+export const Route = createFileRoute("/oauth2/revoke")({
+  server: {handlers: AGENT_DISCOVERY_HANDLERS},
+});

--- a/src/routes/oauth2.token.ts
+++ b/src/routes/oauth2.token.ts
@@ -1,0 +1,6 @@
+import {createFileRoute} from "@tanstack/react-router";
+import {AGENT_DISCOVERY_HANDLERS} from "~/lib/agent-discovery/route-handler";
+
+export const Route = createFileRoute("/oauth2/token")({
+  server: {handlers: AGENT_DISCOVERY_HANDLERS},
+});

--- a/src/routes/oauth2.userinfo.ts
+++ b/src/routes/oauth2.userinfo.ts
@@ -1,0 +1,6 @@
+import {createFileRoute} from "@tanstack/react-router";
+import {AGENT_DISCOVERY_HANDLERS} from "~/lib/agent-discovery/route-handler";
+
+export const Route = createFileRoute("/oauth2/userinfo")({
+  server: {handlers: AGENT_DISCOVERY_HANDLERS},
+});

--- a/src/routes/openapi[.]json.ts
+++ b/src/routes/openapi[.]json.ts
@@ -1,0 +1,6 @@
+import {createFileRoute} from "@tanstack/react-router";
+import {AGENT_DISCOVERY_HANDLERS} from "~/lib/agent-discovery/route-handler";
+
+export const Route = createFileRoute("/openapi.json")({
+  server: {handlers: AGENT_DISCOVERY_HANDLERS},
+});

--- a/src/routes/robots[.]txt.ts
+++ b/src/routes/robots[.]txt.ts
@@ -1,0 +1,6 @@
+import {createFileRoute} from "@tanstack/react-router";
+import {AGENT_DISCOVERY_HANDLERS} from "~/lib/agent-discovery/route-handler";
+
+export const Route = createFileRoute("/robots.txt")({
+  server: {handlers: AGENT_DISCOVERY_HANDLERS},
+});

--- a/src/routes/sitemap[.]xml.ts
+++ b/src/routes/sitemap[.]xml.ts
@@ -1,0 +1,6 @@
+import {createFileRoute} from "@tanstack/react-router";
+import {AGENT_DISCOVERY_HANDLERS} from "~/lib/agent-discovery/route-handler";
+
+export const Route = createFileRoute("/sitemap.xml")({
+  server: {handlers: AGENT_DISCOVERY_HANDLERS},
+});

--- a/src/start.ts
+++ b/src/start.ts
@@ -1,0 +1,51 @@
+import {
+  createCsrfMiddleware,
+  createMiddleware,
+  createStart,
+} from "@tanstack/react-start";
+import {withLinkHeader} from "~/lib/agent-discovery/headers";
+import {wantsMarkdown} from "~/lib/agent-discovery/http";
+import {markdownFromHtmlResponse} from "~/lib/agent-discovery/markdown";
+
+/**
+ * Adds homepage Link headers and converts HTML to markdown when the
+ * client sends Accept: text/markdown. Discovery JSON/XML is served by
+ * dedicated server routes so this file does not import Aptos loaders.
+ */
+const agentReadyMiddleware = createMiddleware().server(
+  async ({next, request}) => {
+    // Start's SSR handler 500s unless Accept includes text/html or */*.
+    // Rewrite markdown-only Accept so the page still renders, then convert.
+    const markdown = wantsMarkdown(request);
+    if (markdown) {
+      try {
+        request.headers.set("Accept", "text/html");
+      } catch {
+        // Request headers are immutable in some runtimes.
+      }
+    }
+
+    const result = await next();
+    const response = result instanceof Response ? result : result.response;
+    const pathname = new URL(request.url).pathname;
+    let outgoing = withLinkHeader(response, pathname);
+    if (markdown) {
+      try {
+        outgoing =
+          (await markdownFromHtmlResponse(outgoing.clone())) ?? outgoing;
+      } catch {
+        // Keep the original HTML if conversion fails.
+      }
+    }
+    if (result instanceof Response) return outgoing;
+    return {...result, response: outgoing};
+  },
+);
+
+const csrfMiddleware = createCsrfMiddleware({
+  filter: (ctx) => ctx.handlerType === "serverFn",
+});
+
+export const startInstance = createStart(() => ({
+  requestMiddleware: [csrfMiddleware, agentReadyMiddleware],
+}));

--- a/tests/e2e/agent-discovery.spec.ts
+++ b/tests/e2e/agent-discovery.spec.ts
@@ -1,0 +1,80 @@
+import {expect, test} from "@playwright/test";
+
+test("publishes agent discovery documents", async ({request}) => {
+  const robots = await request.get("/robots.txt");
+  expect(robots.ok()).toBeTruthy();
+  const robotsBody = await robots.text();
+  expect(robotsBody).toContain("Content-Signal:");
+  expect(robotsBody).toMatch(/Sitemap: https?:\/\/.+\/sitemap\.xml/);
+
+  const sitemap = await request.get("/sitemap.xml");
+  expect(sitemap.ok()).toBeTruthy();
+  expect(await sitemap.text()).toContain("<urlset");
+
+  const catalog = await request.get("/.well-known/api-catalog");
+  expect(catalog.ok()).toBeTruthy();
+  expect(catalog.headers()["content-type"]).toMatch(/linkset\+json/);
+
+  const ard = await request.get("/.well-known/ai-catalog.json");
+  expect(ard.ok()).toBeTruthy();
+  expect(ard.headers()["access-control-allow-origin"]).toBe("*");
+
+  const skills = await request.get("/.well-known/agent-skills/index.json");
+  expect(skills.ok()).toBeTruthy();
+  const index = (await skills.json()) as {skills: unknown[]};
+  expect(index.skills.length).toBeGreaterThan(0);
+
+  const card = await request.get("/.well-known/mcp/server-card.json");
+  expect(card.ok()).toBeTruthy();
+
+  const auth = await request.get("/auth.md");
+  expect(auth.ok()).toBeTruthy();
+  expect(await auth.text()).toMatch(/auth\.md/i);
+
+  const health = await request.get("/api/health");
+  expect(health.ok()).toBeTruthy();
+});
+
+test("homepage advertises Link relations and markdown negotiation", async ({
+  page,
+  request,
+}) => {
+  const html = await request.get("/", {headers: {accept: "text/html"}});
+  expect(html.ok()).toBeTruthy();
+  const link = html.headers().link ?? "";
+  expect(link).toMatch(/rel="?api-catalog"?/);
+
+  const markdown = await request.get("/", {
+    headers: {accept: "text/markdown"},
+  });
+  expect(markdown.ok()).toBeTruthy();
+  expect(markdown.headers()["content-type"]).toMatch(/text\/markdown/);
+  expect(markdown.headers()["x-markdown-tokens"]).toBeTruthy();
+
+  await page.addInitScript(() => {
+    const tools: string[] = [];
+    const modelContext = {
+      registerTool: async (tool: {name: string}) => {
+        tools.push(tool.name);
+      },
+      provideContext: async (input: {tools: Array<{name: string}>}) => {
+        for (const tool of input.tools) tools.push(tool.name);
+      },
+    };
+    Object.defineProperty(navigator, "modelContext", {
+      configurable: true,
+      value: modelContext,
+    });
+    (window as unknown as {__webmcpTools: string[]}).__webmcpTools = tools;
+  });
+
+  await page.goto("/");
+  await expect
+    .poll(async () =>
+      page.evaluate(
+        () =>
+          (window as unknown as {__webmcpTools?: string[]}).__webmcpTools ?? [],
+      ),
+    )
+    .toEqual(expect.arrayContaining(["list_proposals", "get_proposal"]));
+});

--- a/tests/unit/agent-discovery.test.ts
+++ b/tests/unit/agent-discovery.test.ts
@@ -1,0 +1,326 @@
+import {readFileSync} from "node:fs";
+import {dirname, resolve} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {handleAgentDiscoveryRequest} from "~/lib/agent-discovery/dispatch";
+import {homepageLinkHeaderValue} from "~/lib/agent-discovery/headers";
+import {wantsMarkdown} from "~/lib/agent-discovery/http";
+import {
+  countMarkdownTokens,
+  htmlToMarkdown,
+} from "~/lib/agent-discovery/markdown";
+import {
+  buildAuthMd,
+  buildAuthorizationServerMetadata,
+  buildProtectedResourceMetadata,
+} from "~/lib/agent-discovery/oauth";
+import {absoluteUrl, publicOrigin} from "~/lib/agent-discovery/origin";
+import {buildRobotsTxt} from "~/lib/agent-discovery/robots";
+import {
+  buildSkillsIndex,
+  GOVERNANCE_SKILLS,
+  skillDigest,
+  skillMarkdown,
+} from "~/lib/agent-discovery/skills";
+
+vi.mock("~/lib/governance/load-forum", () => ({
+  loadProposalCount: vi.fn(async () => 2),
+  loadVotingForum: vi.fn(),
+}));
+
+const ORIGIN = "https://governance.example.test";
+
+const previousSiteOrigin = process.env.SITE_ORIGIN;
+
+beforeEach(() => {
+  delete process.env.SITE_ORIGIN;
+});
+
+afterEach(() => {
+  if (previousSiteOrigin === undefined) delete process.env.SITE_ORIGIN;
+  else process.env.SITE_ORIGIN = previousSiteOrigin;
+});
+
+function req(path: string, init: RequestInit = {}, origin = ORIGIN): Request {
+  return new Request(`${origin}${path}`, init);
+}
+
+async function dispatch(path: string, init?: RequestInit): Promise<Response> {
+  const response = await handleAgentDiscoveryRequest(req(path, init));
+  if (!response) throw new Error(`No handler for ${path}`);
+  return response;
+}
+
+describe("publicOrigin", () => {
+  it("prefers SITE_ORIGIN over the request URL", () => {
+    process.env.SITE_ORIGIN = "https://governance.aptosfoundation.org";
+    expect(publicOrigin(req("/"))).toBe(
+      "https://governance.aptosfoundation.org",
+    );
+  });
+
+  it("uses x-forwarded-host when SITE_ORIGIN is unset", () => {
+    delete process.env.SITE_ORIGIN;
+    const request = new Request("http://127.0.0.1/internal", {
+      headers: {
+        "x-forwarded-host": "governance.aptosfoundation.org",
+        "x-forwarded-proto": "https",
+      },
+    });
+    expect(publicOrigin(request)).toBe(
+      "https://governance.aptosfoundation.org",
+    );
+  });
+});
+
+describe("robots.txt and sitemap", () => {
+  it("declares Content-Signal preferences and a Sitemap URL", async () => {
+    const body = buildRobotsTxt(ORIGIN);
+    expect(body).toMatch(
+      /Content-Signal: ai-train=no, search=yes, ai-input=yes/,
+    );
+    expect(body).toContain(`Sitemap: ${ORIGIN}/sitemap.xml`);
+    expect(body).toContain(`Agentmap: ${ORIGIN}/.well-known/ai-catalog.json`);
+
+    const response = await dispatch("/robots.txt");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toMatch(/text\/plain/);
+    expect(await response.text()).toBe(body);
+  });
+
+  it("lists canonical proposal URLs in sitemap.xml", async () => {
+    const response = await dispatch("/sitemap.xml");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toMatch(/xml/);
+    const xml = await response.text();
+    expect(xml).toContain("<urlset");
+    expect(xml).toContain(`${ORIGIN}/`);
+    expect(xml).toContain(`${ORIGIN}/proposal/0`);
+    expect(xml).toContain(`${ORIGIN}/proposal/1`);
+    expect(xml).not.toContain(`${ORIGIN}/proposal/2`);
+  });
+});
+
+describe("discovery documents", () => {
+  it("serves an RFC 9727 api-catalog linkset", async () => {
+    const response = await dispatch("/.well-known/api-catalog");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toMatch(
+      /application\/linkset\+json/,
+    );
+    const body = (await response.json()) as {
+      linkset: Array<{
+        anchor: string;
+        "service-desc": unknown;
+        "service-doc": unknown;
+        status: unknown;
+      }>;
+    };
+    expect(body.linkset.length).toBeGreaterThan(0);
+    for (const entry of body.linkset) {
+      expect(entry.anchor).toMatch(/^https?:\/\//);
+      expect(entry["service-desc"]).toBeDefined();
+      expect(entry["service-doc"]).toBeDefined();
+      expect(entry.status).toBeDefined();
+    }
+  });
+
+  it("serves ARD ai-catalog.json with CORS", async () => {
+    const response = await dispatch("/.well-known/ai-catalog.json");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    const body = (await response.json()) as {
+      specVersion: string;
+      host: {displayName: string; identifier: string};
+      entries: Array<{
+        identifier: string;
+        displayName: string;
+        type: string;
+        url?: string;
+        data?: unknown;
+        representativeQueries: string[];
+      }>;
+    };
+    expect(body.specVersion).toBeTruthy();
+    expect(body.host.displayName).toBe("Aptos Governance");
+    expect(body.entries.length).toBeGreaterThan(0);
+    for (const entry of body.entries) {
+      expect(entry.identifier).toMatch(/^urn:air:/);
+      expect(entry.type).toBeTruthy();
+      expect(Boolean(entry.url) !== Boolean(entry.data)).toBe(true);
+      expect(entry.representativeQueries.length).toBeGreaterThanOrEqual(2);
+      expect(entry.representativeQueries.length).toBeLessThanOrEqual(5);
+    }
+  });
+
+  it("publishes OAuth PRM, AS metadata, and OpenID configuration", async () => {
+    const prmRes = await dispatch("/.well-known/oauth-protected-resource");
+    const asRes = await dispatch("/.well-known/oauth-authorization-server");
+    const oidcRes = await dispatch("/.well-known/openid-configuration");
+    expect(prmRes.status).toBe(200);
+    expect(asRes.status).toBe(200);
+    expect(oidcRes.status).toBe(200);
+
+    const prm = (await prmRes.json()) as ReturnType<
+      typeof buildProtectedResourceMetadata
+    >;
+    const as = (await asRes.json()) as ReturnType<
+      typeof buildAuthorizationServerMetadata
+    >;
+    const oidc = (await oidcRes.json()) as {
+      issuer: string;
+      authorization_endpoint: string;
+      token_endpoint: string;
+      jwks_uri: string;
+      grant_types_supported: string[];
+      response_types_supported: string[];
+    };
+
+    expect(prm.resource).toBe(`${ORIGIN}/`);
+    expect(prm.authorization_servers).toEqual([ORIGIN]);
+    expect(prm.bearer_methods_supported).toContain("header");
+    expect(as.issuer).toBe(ORIGIN);
+    expect(as.agent_auth.register_uri).toContain("/agent/identity");
+    expect(as.agent_auth.skill).toBe(`${ORIGIN}/auth.md`);
+    expect(oidc.issuer).toBe(as.issuer);
+    expect(oidc.authorization_endpoint).toBeTruthy();
+    expect(oidc.token_endpoint).toBeTruthy();
+    expect(oidc.jwks_uri).toBeTruthy();
+    expect(oidc.grant_types_supported.length).toBeGreaterThan(0);
+    expect(oidc.response_types_supported.length).toBeGreaterThan(0);
+  });
+
+  it("serves auth.md with the required heading", async () => {
+    const response = await dispatch("/auth.md");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toMatch(/text\/markdown/);
+    const body = await response.text();
+    expect(body).toMatch(/^# auth\.md/m);
+    expect(body).toContain("/agent/identity");
+  });
+
+  it("keeps public markdown artifacts identical to the generated documents", () => {
+    const root = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+    expect(readFileSync(resolve(root, "public/auth.md"), "utf8")).toBe(
+      buildAuthMd(),
+    );
+    for (const skill of GOVERNANCE_SKILLS) {
+      const file = readFileSync(
+        resolve(root, `public/.well-known/agent-skills/${skill.name}/SKILL.md`),
+        "utf8",
+      );
+      expect(file).toBe(skill.markdown);
+    }
+  });
+
+  it("serves an MCP server card with serverInfo, transport, and capabilities", async () => {
+    const response = await dispatch("/.well-known/mcp/server-card.json");
+    expect(response.status).toBe(200);
+    const card = (await response.json()) as {
+      serverInfo: {name: string; version: string};
+      transport: {endpoint: string};
+      capabilities: unknown;
+    };
+    expect(card.serverInfo.name).toBe("aptos-governance");
+    expect(card.serverInfo.version).toBeTruthy();
+    expect(card.transport.endpoint).toBe("/mcp");
+    expect(card.capabilities).toBeTruthy();
+  });
+
+  it("publishes an agent-skills index with matching sha256 digests", async () => {
+    const response = await dispatch("/.well-known/agent-skills/index.json");
+    expect(response.status).toBe(200);
+    const index = (await response.json()) as ReturnType<
+      typeof buildSkillsIndex
+    >;
+    expect(index.$schema).toBe(
+      "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+    );
+    expect(index.skills).toHaveLength(GOVERNANCE_SKILLS.length);
+    for (const skill of index.skills) {
+      expect(skill.name).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+      expect(skill.type).toBe("skill-md");
+      const artifact = await dispatch(
+        `/.well-known/agent-skills/${skill.name}/SKILL.md`,
+      );
+      expect(artifact.status).toBe(200);
+      const markdown = await artifact.text();
+      expect(skill.digest).toBe(skillDigest(markdown));
+      expect(markdown).toBe(
+        skillMarkdown(
+          GOVERNANCE_SKILLS.find((item) => item.name === skill.name)!,
+          ORIGIN,
+        ),
+      );
+    }
+  });
+});
+
+describe("oauth registration", () => {
+  it("issues an anonymous credential and exchanges it at the token endpoint", async () => {
+    const register = await dispatch("/agent/identity", {
+      method: "POST",
+      headers: {"content-type": "application/json"},
+      body: JSON.stringify({type: "anonymous"}),
+    });
+    expect(register.status).toBe(200);
+    const issued = (await register.json()) as {
+      access_token: string;
+      identity_assertion: string;
+    };
+    expect(issued.access_token).toBeTruthy();
+
+    const token = await dispatch("/oauth2/token", {
+      method: "POST",
+      headers: {"content-type": "application/x-www-form-urlencoded"},
+      body: `grant_type=${encodeURIComponent("urn:ietf:params:oauth:grant-type:jwt-bearer")}&assertion=${issued.identity_assertion}`,
+    });
+    expect(token.status).toBe(200);
+    const exchanged = (await token.json()) as {access_token: string};
+    expect(exchanged.access_token).toBeTruthy();
+  });
+});
+
+describe("markdown negotiation helpers", () => {
+  it("prefers text/markdown when it is the Accept type", () => {
+    expect(wantsMarkdown(req("/", {headers: {accept: "text/markdown"}}))).toBe(
+      true,
+    );
+    expect(wantsMarkdown(req("/", {headers: {accept: "text/html"}}))).toBe(
+      false,
+    );
+  });
+
+  it("converts HTML main content to markdown", () => {
+    const md = htmlToMarkdown(`
+      <html><head><title>Hello</title></head>
+      <body>
+        <main>
+          <h1>Hello</h1>
+          <p>See <a href="/docs/api">the docs</a>.</p>
+        </main>
+      </body></html>
+    `);
+    expect(md).toContain("# Hello");
+    expect(md).toContain("[the docs](/docs/api)");
+    expect(countMarkdownTokens(md)).toBeGreaterThan(0);
+  });
+});
+
+describe("link headers", () => {
+  it("includes registered relation types", () => {
+    const value = homepageLinkHeaderValue();
+    expect(value).toContain('rel="api-catalog"');
+    expect(value).toContain('rel="service-desc"');
+    expect(value).toContain('rel="service-doc"');
+    expect(value).toContain('rel="describedby"');
+  });
+});
+
+describe("absoluteUrl", () => {
+  it("joins origin and path", () => {
+    expect(absoluteUrl("https://example.com/", "/x")).toBe(
+      "https://example.com/x",
+    );
+  });
+});

--- a/tests/unit/deployment-config.test.ts
+++ b/tests/unit/deployment-config.test.ts
@@ -33,6 +33,10 @@ describe("deployment config", () => {
     }
   });
 
+  it("does not keep a static robots.txt that would shadow the generated file", () => {
+    expect(existsSync(resolve(rootDir, "public/robots.txt"))).toBe(false);
+  });
+
   it("keeps the backend key unprefixed and the frontend key Vite-prefixed", () => {
     const example = readFileSync(resolve(rootDir, ".env.example"), "utf8");
     expect(example).toMatch(/^APTOS_BUILD_API_KEY=/m);
@@ -48,12 +52,22 @@ describe("deployment config", () => {
       headers: Array<{key: string; value: string}>;
     }>;
     expect(headers.length).toBeGreaterThan(0);
-    for (const entry of headers) {
+    const pageRules = headers.filter((entry) =>
+      ["/", "/proposal/:path*"].includes(entry.source),
+    );
+    expect(pageRules.length).toBeGreaterThan(0);
+    for (const entry of pageRules) {
       const cacheControl = entry.headers.find(
         (header) => header.key === "Cache-Control",
       );
       expect(cacheControl?.value).toBe(PUBLIC_PAGE_CACHE_CONTROL);
     }
+
+    const homepage = headers.find((entry) => entry.source === "/");
+    const link = homepage?.headers.find((header) => header.key === "Link");
+    expect(link?.value).toMatch(/rel="api-catalog"/);
+    expect(link?.value).toMatch(/rel="service-desc"/);
+    expect(link?.value).toMatch(/rel="service-doc"/);
   });
 
   it("uses patched nitro and uuid versions for known GHSA advisories", () => {

--- a/vercel.json
+++ b/vercel.json
@@ -16,6 +16,10 @@
         {
           "key": "CDN-Cache-Control",
           "value": "public, s-maxage=15, stale-while-revalidate=45"
+        },
+        {
+          "key": "Link",
+          "value": "</.well-known/api-catalog>; rel=\"api-catalog\", </openapi.json>; rel=\"service-desc\"; type=\"application/json\", </docs/api>; rel=\"service-doc\"; type=\"text/markdown\", </.well-known/ai-catalog.json>; rel=\"describedby\"; type=\"application/json\""
         }
       ]
     },
@@ -29,6 +33,28 @@
         {
           "key": "CDN-Cache-Control",
           "value": "public, s-maxage=15, stale-while-revalidate=45"
+        }
+      ]
+    },
+    {
+      "source": "/.well-known/:path*",
+      "headers": [
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=300"
+        }
+      ]
+    },
+    {
+      "source": "/sitemap.xml",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=300"
         }
       ]
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This adds the HTTP surfaces agents need to find Aptos Governance, read it as markdown, and call a public proposals API.

## What landed

- **Sitemap + robots:** `/sitemap.xml` lists `/`, `/delegation`, `/docs/api`, and every on-chain proposal URL (ids `0..next_proposal_id-1`). `/robots.txt` allows those public paths, sets `Content-Signal: ai-train=no, search=yes, ai-input=yes`, and points at the sitemap plus ARD catalog (`Agentmap`).
- **Link headers (RFC 8288):** Homepage responses include `rel="api-catalog"`, `service-desc`, `service-doc`, and `describedby` (Vercel + SSR).
- **API catalog (RFC 9727):** `/.well-known/api-catalog` as `application/linkset+json` with `service-desc` / `service-doc` / `status`.
- **ARD:** `/.well-known/ai-catalog.json` with CORS `*`, `specVersion`, host, and entries for MCP, OpenAPI, a skill, and auth.md.
- **MCP:** `/.well-known/mcp/server-card.json` plus Streamable HTTP `POST /mcp` (`list_proposals`, `get_proposal`).
- **Agent skills:** `/.well-known/agent-skills/index.json` (`$schema` 0.2.0, sha256 digests) and `SKILL.md` files.
- **OAuth / auth.md:** `/auth.md`, `/.well-known/oauth-protected-resource`, `/.well-known/oauth-authorization-server` (with `agent_auth`), OpenID configuration, anonymous `POST /agent/identity`, and `/oauth2/token`. Read APIs stay public; votes remain wallet-signed on chain.
- **Markdown for agents:** `Accept: text/markdown` returns `text/markdown` and `x-markdown-tokens` (Start otherwise 500s unless Accept includes `text/html`).
- **WebMCP:** Registers `list_proposals`, `get_proposal`, and `open_proposal` on page load.

Public REST: `GET /api/health`, `/api/proposals`, `/api/proposals/:id`, `/api/proposals/:id/votes`. OpenAPI at `/openapi.json`.

## DNS-AID (out of band)

SVCB/HTTPS records under `_agents.<apex>` cannot be published from this app. Operators need to add the records in `dns/agents.zone` and sign the zone. See `docs/dns-aid.md`.

## Validation

- `pnpm typecheck`
- `pnpm test` (167)
- `pnpm build`
- `pnpm lint`

Checked locally: sitemap/robots/catalogs/auth.md/skills return 200; homepage `Link` headers; `Accept: text/markdown` on `/` returns markdown after the existing search-param redirect.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35f19989-bcaf-459e-958c-afed7314f553?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35f19989-bcaf-459e-958c-afed7314f553&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

